### PR TITLE
fix(#139): Fix translation checkbox bugs and UI improvements

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Index.cshtml
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Index.cshtml
@@ -68,15 +68,6 @@
                 @if (Model.State == "closed") { <option value="closed" selected>Zavřený</option> } else { <option value="closed">Zavřený</option> }
             </select>
 
-            <label class="translate-checkbox-label">
-                <input type="checkbox"
-                       name="TranslateToCzech"
-                       id="translateToCzechCheckbox"
-                       class="translate-checkbox"
-                       @(Model.TranslateToCzech ? "checked" : "") />
-                Přeložit do češtiny
-            </label>
-
             <label>Položek na stránku:</label>
             <select name="PageSize" class="page-size-select" onchange="document.getElementById('searchForm').submit();">
                 @foreach (var size in Model.PageSizeOptions)
@@ -91,6 +82,18 @@
                     }
                 }
             </select>
+
+            @* Hidden field ensures "false" is sent when checkbox is unchecked *@
+            <input type="hidden" name="TranslateToCzech" value="false" />
+            <label class="translate-checkbox-label">
+                <input type="checkbox"
+                       name="TranslateToCzech"
+                       id="translateToCzechCheckbox"
+                       class="translate-checkbox"
+                       value="true"
+                       @(Model.TranslateToCzech ? "checked" : "") />
+                Přeložit do češtiny
+            </label>
         </div>
         <input type="hidden" name="PageNum" value="1" />
     </form>

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/css/site.css
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/css/site.css
@@ -129,30 +129,32 @@ footer {
     outline: none;
 }
 
-/* Translate to Czech checkbox */
+/* Translate to Czech checkbox - styled to match grey dropdowns */
 .translate-checkbox-label {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
     padding: 0.5rem 1rem;
-    background-color: #f0f9ff;
-    border: 1px solid #0ea5e9;
+    background-color: #fff;
+    border: 1px solid #ddd;
     border-radius: 6px;
     font-weight: 500;
-    color: #0369a1;
-    transition: background-color 0.2s;
+    color: #333;
+    transition: background-color 0.2s, border-color 0.2s;
+    margin-left: 1rem;
 }
 
 .translate-checkbox-label:hover {
-    background-color: #e0f2fe;
+    background-color: #f5f5f5;
+    border-color: #bbb;
 }
 
 .translate-checkbox {
     width: 18px;
     height: 18px;
     cursor: pointer;
-    accent-color: #0ea5e9;
+    accent-color: #666;
 }
 
 /* Results */

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/js/issue-updates.js
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/js/issue-updates.js
@@ -4,13 +4,15 @@
 
     let connection = null;
     let subscribedIssueIds = [];
-
-    // Get translation preference from checkbox (default: true = translate to Czech)
-    const translateCheckbox = document.getElementById('translateToCzechCheckbox');
-    const translateToCzech = translateCheckbox ? translateCheckbox.checked : true;
+    let translateToCzech = true; // Will be read from checkbox after DOM is ready
 
     // Initialize SignalR connection when DOM is ready
     document.addEventListener('DOMContentLoaded', function () {
+        // Read translation preference from checkbox AFTER DOM is ready
+        const translateCheckbox = document.getElementById('translateToCzechCheckbox');
+        translateToCzech = translateCheckbox ? translateCheckbox.checked : true;
+        console.log('[issue-updates] Translation preference:', translateToCzech);
+
         initializeSignalR();
     });
 


### PR DESCRIPTION
## Summary
Fixes multiple bugs in the "Přeložit do češtiny" checkbox functionality and improves UI consistency.

## Changes

| Bug | Problem | Solution |
|-----|---------|----------|
| Bug 1 | Pagination breaks translation | Moved checkbox reading to DOMContentLoaded |
| Bug 2 | Checkbox resets on search | Added hidden field with value="false" |
| Bug 3 | Blue styling doesn't match | Changed to grey style (#ddd, #666) |
| UI | Control order | Reordered: State → Items per page → Translate |

## Changed Files
- `Pages/Index.cshtml` - hidden field + control order
- `wwwroot/js/issue-updates.js` - DOMContentLoaded timing
- `wwwroot/css/site.css` - grey checkbox style

## Testing
- [x] Checkbox state persists across searches
- [x] Translation works on all pages (pagination)
- [x] Checkbox styling matches other controls
- [x] Controls are in correct order

Closes #139