### PR TITLE
feat(#138): Upgrade all projects from .NET 9 to .NET 10

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.csproj
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>c196aa00-c5a4-455a-8481-8fdccf67c02b</UserSecretsId>
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="9.0.0" />
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="10.0.0" />
     <PackageReference Include="Markdig" Version="0.44.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Olbrasoft.GitHub.Issues.Business/Olbrasoft.GitHub.Issues.Business.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Business/Olbrasoft.GitHub.Issues.Business.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>59ba74e4-0cb4-4761-8b8e-b02c3ee65bf1</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+    <PackageReference Include="EFCore.NamingConventions" Version="10.0.0-rc.2" />
     <PackageReference Include="EFCore.SqlServer.VectorSearch" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.*">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.*" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.*" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.*" />
     <PackageReference Include="Olbrasoft.Data.Cqrs.EntityFrameworkCore" Version="1.8.0" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.2.2" />
   </ItemGroup>

--- a/src/Olbrasoft.GitHub.Issues.Data/Olbrasoft.GitHub.Issues.Data.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Data/Olbrasoft.GitHub.Issues.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Olbrasoft.GitHub.Issues.Migrations.PostgreSQL/Olbrasoft.GitHub.Issues.Migrations.PostgreSQL.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Migrations.PostgreSQL/Olbrasoft.GitHub.Issues.Migrations.PostgreSQL.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.*">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.*" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.*" />
     <PackageReference Include="Pgvector.EntityFrameworkCore" Version="0.2.*" />
   </ItemGroup>
 

--- a/src/Olbrasoft.GitHub.Issues.Migrations.SqlServer/Olbrasoft.GitHub.Issues.Migrations.SqlServer.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Migrations.SqlServer/Olbrasoft.GitHub.Issues.Migrations.SqlServer.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.*">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Olbrasoft.GitHub.Issues.Sync/Olbrasoft.GitHub.Issues.Sync.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Sync/Olbrasoft.GitHub.Issues.Sync.csproj
@@ -2,19 +2,19 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>c3e33a2c-a592-4da4-be1d-6329d16f7213</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
     <PackageReference Include="Octokit" Version="13.0.1" />
   </ItemGroup>

--- a/test/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Tests/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Tests.csproj
+++ b/test/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Tests/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Olbrasoft.GitHub.Issues.Business.Tests/Olbrasoft.GitHub.Issues.Business.Tests.csproj
+++ b/test/Olbrasoft.GitHub.Issues.Business.Tests/Olbrasoft.GitHub.Issues.Business.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.Tests/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.Tests.csproj
+++ b/test/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.Tests/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/test/Olbrasoft.GitHub.Issues.Data.Tests/Olbrasoft.GitHub.Issues.Data.Tests.csproj
+++ b/test/Olbrasoft.GitHub.Issues.Data.Tests/Olbrasoft.GitHub.Issues.Data.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Olbrasoft.GitHub.Issues.Sync.Tests/Olbrasoft.GitHub.Issues.Sync.Tests.csproj
+++ b/test/Olbrasoft.GitHub.Issues.Sync.Tests/Olbrasoft.GitHub.Issues.Sync.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary
Upgrade all 12 projects from .NET 9 to .NET 10.

## Changes

| Package | Before | After |
|---------|--------|-------|
| TargetFramework | net9.0 | net10.0 |
| Microsoft.EntityFrameworkCore.* | 9.x | 10.0.* |
| Microsoft.Extensions.* | 9.x | 10.0.* |
| Npgsql.EntityFrameworkCore.PostgreSQL | 9.x | 10.0.* |
| EFCore.NamingConventions | 8.x | 10.0.0-rc.2 |
| EFCore.SqlServer.VectorSearch | 9.0.0 | 9.0.0 (no 10.x available) |

## Testing
- ✅ Build successful
- ✅ All 134 tests passed

## Notes
- `EFCore.NamingConventions` uses RC2 as stable 10.0 is not yet released
- `EFCore.SqlServer.VectorSearch` stays at 9.0.0 as 10.x doesn't exist yet

Closes #138