### PR TITLE
fix(#141): Fix checkbox duplicate URL param and detail page Czech translation

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Index.cshtml
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Index.cshtml
@@ -83,17 +83,15 @@
                 }
             </select>
 
-            @* Hidden field ensures "false" is sent when checkbox is unchecked *@
-            <input type="hidden" name="TranslateToCzech" value="false" />
             <label class="translate-checkbox-label">
                 <input type="checkbox"
-                       name="TranslateToCzech"
                        id="translateToCzechCheckbox"
                        class="translate-checkbox"
-                       value="true"
-                       @(Model.TranslateToCzech ? "checked" : "") />
+                       @(Model.TranslateToCzech ? "checked" : "")
+                       onchange="updateTranslateHiddenField(this)" />
                 Přeložit do češtiny
             </label>
+            <input type="hidden" name="TranslateToCzech" id="translateToCzechHidden" value="@(Model.TranslateToCzech ? "true" : "false")" />
         </div>
         <input type="hidden" name="PageNum" value="1" />
     </form>
@@ -250,6 +248,11 @@
         // Clear search function - clears session and reloads page
         function clearSearch() {
             document.getElementById('clearSearchForm').submit();
+        }
+
+        // Update hidden field when checkbox changes (prevents duplicate URL params)
+        function updateTranslateHiddenField(checkbox) {
+            document.getElementById('translateToCzechHidden').value = checkbox.checked ? 'true' : 'false';
         }
     </script>
     <script src="~/js/repo-filter.js"></script>


### PR DESCRIPTION
## Summary
Fixes critical bugs in checkbox and translation functionality.

## Changes

### Bug 1: Duplicate TranslateToCzech in URL
- **Problem:** Hidden field + checkbox pattern sent both `false` and `true` values
- **Solution:** Single hidden field with JavaScript `onchange` handler

### Bug 2: Detail page doesn't translate to Czech
- **Problem:** SignalR connection closed immediately after English summary
- **Solution:** Track `englishReceived`/`czechReceived` states, only disconnect when both complete

### Bug 3: Inconsistent checkbox state
- **Fixed:** As side effect of Bug 1 fix

## Files Changed
- `Pages/Index.cshtml` - new checkbox pattern
- `wwwroot/js/detail-updates.js` - dual summary tracking

## Testing
- ✅ Build passes
- ✅ 134 tests pass

Fixes #141