### PR TITLE
feat(#136): Add Text.Transformation projects (Phase 1)

### DIFF
--- a/GitHub.Issues.sln
+++ b/GitHub.Issues.sln
@@ -31,6 +31,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Olbrasoft.GitHub.Issues.Mig
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Olbrasoft.GitHub.Issues.Migrations.SqlServer", "src\Olbrasoft.GitHub.Issues.Migrations.SqlServer\Olbrasoft.GitHub.Issues.Migrations.SqlServer.csproj", "{56391E52-718B-4ACF-87BA-3C8194B3D2B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions", "src\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions.csproj", "{669ED17A-6308-4581-87C4-894869886A36}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Olbrasoft.GitHub.Issues.Text.Transformation", "src\Olbrasoft.GitHub.Issues.Text.Transformation\Olbrasoft.GitHub.Issues.Text.Transformation.csproj", "{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Olbrasoft.GitHub.Issues.Text.Transformation.Ollama", "src\Olbrasoft.GitHub.Issues.Text.Transformation.Ollama\Olbrasoft.GitHub.Issues.Text.Transformation.Ollama.csproj", "{F532D81F-553A-49B3-B471-0C2D90D54934}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Olbrasoft.GitHub.Issues.Text.Transformation.Cohere", "src\Olbrasoft.GitHub.Issues.Text.Transformation.Cohere\Olbrasoft.GitHub.Issues.Text.Transformation.Cohere.csproj", "{FBE5FDEA-8998-4090-95D3-8A03699D4F97}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible", "src\Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible\Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible.csproj", "{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -185,6 +195,66 @@ Global
 		{56391E52-718B-4ACF-87BA-3C8194B3D2B1}.Release|x64.Build.0 = Release|Any CPU
 		{56391E52-718B-4ACF-87BA-3C8194B3D2B1}.Release|x86.ActiveCfg = Release|Any CPU
 		{56391E52-718B-4ACF-87BA-3C8194B3D2B1}.Release|x86.Build.0 = Release|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Debug|x64.Build.0 = Debug|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Debug|x86.Build.0 = Debug|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Release|x64.ActiveCfg = Release|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Release|x64.Build.0 = Release|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Release|x86.ActiveCfg = Release|Any CPU
+		{669ED17A-6308-4581-87C4-894869886A36}.Release|x86.Build.0 = Release|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Debug|x64.Build.0 = Debug|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Debug|x86.Build.0 = Debug|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Release|x64.ActiveCfg = Release|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Release|x64.Build.0 = Release|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Release|x86.ActiveCfg = Release|Any CPU
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853}.Release|x86.Build.0 = Release|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Debug|x64.Build.0 = Debug|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Debug|x86.Build.0 = Debug|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Release|x64.ActiveCfg = Release|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Release|x64.Build.0 = Release|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Release|x86.ActiveCfg = Release|Any CPU
+		{F532D81F-553A-49B3-B471-0C2D90D54934}.Release|x86.Build.0 = Release|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Debug|x64.Build.0 = Debug|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Debug|x86.Build.0 = Debug|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Release|x64.ActiveCfg = Release|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Release|x64.Build.0 = Release|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Release|x86.ActiveCfg = Release|Any CPU
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97}.Release|x86.Build.0 = Release|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Debug|x64.Build.0 = Debug|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Debug|x86.Build.0 = Debug|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Release|x64.ActiveCfg = Release|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Release|x64.Build.0 = Release|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Release|x86.ActiveCfg = Release|Any CPU
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -202,6 +272,11 @@ Global
 		{724345F6-0538-48B4-A7F3-8D20D56BD155} = {EAC845CB-591C-4C68-A151-4D75CBD553AE}
 		{F4779BE1-C274-478B-9369-46B900FCFB4A} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{56391E52-718B-4ACF-87BA-3C8194B3D2B1} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{669ED17A-6308-4581-87C4-894869886A36} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{C3FFD0CE-D81C-4E03-8719-2F579BE7A853} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{F532D81F-553A-49B3-B471-0C2D90D54934} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{FBE5FDEA-8998-4090-95D3-8A03699D4F97} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{723C856F-FFC2-4094-BA3F-C6AD56EFB5A2} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {12345678-ABCD-EF12-3456-7890ABCDEF12}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/AiProvidersSettings.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/AiProvidersSettings.cs
@@ -1,0 +1,41 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Settings for AI providers used in summarization and translation.
+/// </summary>
+public class AiProvidersSettings
+{
+    public AiProviderConfig Cerebras { get; set; } = new();
+    public AiProviderConfig Groq { get; set; } = new();
+    public CohereProviderConfig Cohere { get; set; } = new();
+}
+
+/// <summary>
+/// Configuration for Cohere provider (uses different API format).
+/// </summary>
+public class CohereProviderConfig
+{
+    /// <summary>API endpoint URL.</summary>
+    public string Endpoint { get; set; } = "https://api.cohere.com/v2/";
+
+    /// <summary>Models to use for translation, in priority order.</summary>
+    public string[] TranslationModels { get; set; } = ["command-a-translate-08-2025", "c4ai-aya-expanse-32b"];
+
+    /// <summary>API keys to rotate through.</summary>
+    public string[] Keys { get; set; } = [];
+}
+
+/// <summary>
+/// Configuration for a single AI provider.
+/// </summary>
+public class AiProviderConfig
+{
+    /// <summary>API endpoint URL.</summary>
+    public string Endpoint { get; set; } = string.Empty;
+
+    /// <summary>Models to use, in priority order.</summary>
+    public string[] Models { get; set; } = [];
+
+    /// <summary>API keys to rotate through. Store in User Secrets!</summary>
+    public string[] Keys { get; set; } = [];
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/EmbeddingProvider.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/EmbeddingProvider.cs
@@ -1,0 +1,17 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Available embedding providers.
+/// </summary>
+public enum EmbeddingProvider
+{
+    /// <summary>
+    /// Local Ollama instance (requires Ollama running on localhost).
+    /// </summary>
+    Ollama,
+
+    /// <summary>
+    /// Cohere cloud API (requires API key).
+    /// </summary>
+    Cohere
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/EmbeddingSettings.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/EmbeddingSettings.cs
@@ -1,0 +1,101 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Configuration for embedding services.
+/// </summary>
+public class EmbeddingSettings
+{
+    /// <summary>
+    /// Which embedding provider to use. Default: Ollama
+    /// </summary>
+    public EmbeddingProvider Provider { get; set; } = EmbeddingProvider.Ollama;
+
+    /// <summary>
+    /// Vector dimensions for the embedding model.
+    /// Ollama nomic-embed-text: 768, Cohere embed-multilingual-v3.0: 1024
+    /// </summary>
+    public int Dimensions { get; set; } = 768;
+
+    // === Ollama-specific settings ===
+
+    /// <summary>
+    /// Base URL for Ollama API. Default: http://localhost:11434
+    /// </summary>
+    public string OllamaBaseUrl { get; set; } = "http://localhost:11434";
+
+    /// <summary>
+    /// Ollama embedding model name. Default: nomic-embed-text (768 dimensions)
+    /// </summary>
+    public string OllamaModel { get; set; } = "nomic-embed-text";
+
+    /// <summary>
+    /// Maximum retries when waiting for Ollama to start. Default: 30 (30 seconds)
+    /// </summary>
+    public int MaxStartupRetries { get; set; } = 30;
+
+    /// <summary>
+    /// Delay between startup retry attempts in milliseconds. Default: 1000 (1 second)
+    /// </summary>
+    public int StartupRetryDelayMs { get; set; } = 1000;
+
+    // === Cohere-specific settings ===
+
+    /// <summary>
+    /// Array of Cohere API keys for round-robin rotation.
+    /// Store in User Secrets or Azure App Settings, NOT in appsettings.json!
+    /// Example: Embeddings:CohereApiKeys:0 = "key1", Embeddings:CohereApiKeys:1 = "key2"
+    /// </summary>
+    public string[] CohereApiKeys { get; set; } = [];
+
+    /// <summary>
+    /// Legacy single Cohere API key. If set and CohereApiKeys is empty, this will be used.
+    /// Prefer using CohereApiKeys array for multiple keys.
+    /// </summary>
+    public string? CohereApiKey { get; set; }
+
+    /// <summary>
+    /// Cohere embedding model. Default: embed-multilingual-v3.0 (1024 dimensions, supports Czech)
+    /// </summary>
+    public string CohereModel { get; set; } = "embed-multilingual-v3.0";
+
+    /// <summary>
+    /// Gets all configured Cohere API keys (combines array and legacy single key).
+    /// </summary>
+    public IReadOnlyList<string> GetCohereApiKeys()
+    {
+        var keys = new List<string>();
+
+        if (CohereApiKeys.Length > 0)
+        {
+            keys.AddRange(CohereApiKeys.Where(k => !string.IsNullOrWhiteSpace(k)));
+        }
+
+        // Add legacy single key if array is empty
+        if (keys.Count == 0 && !string.IsNullOrWhiteSpace(CohereApiKey))
+        {
+            keys.Add(CohereApiKey);
+        }
+
+        return keys;
+    }
+
+    // === Legacy property mappings (for backward compatibility) ===
+
+    /// <summary>
+    /// Legacy: maps to OllamaBaseUrl for backward compatibility.
+    /// </summary>
+    public string BaseUrl
+    {
+        get => OllamaBaseUrl;
+        set => OllamaBaseUrl = value;
+    }
+
+    /// <summary>
+    /// Legacy: maps to OllamaModel for backward compatibility.
+    /// </summary>
+    public string Model
+    {
+        get => OllamaModel;
+        set => OllamaModel = value;
+    }
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/IEmbeddingService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/IEmbeddingService.cs
@@ -1,0 +1,43 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Specifies the type of input for embedding generation.
+/// Some providers (like Cohere) optimize embeddings based on input type.
+/// </summary>
+public enum EmbeddingInputType
+{
+    /// <summary>
+    /// Use for documents being indexed/stored (e.g., issue content).
+    /// </summary>
+    Document,
+
+    /// <summary>
+    /// Use for search queries entered by users.
+    /// </summary>
+    Query
+}
+
+/// <summary>
+/// Generic embedding service interface following Interface Segregation Principle (ISP).
+/// Can be implemented by Ollama, OpenAI, Azure OpenAI, Cohere, or other embedding providers.
+/// </summary>
+public interface IEmbeddingService
+{
+    /// <summary>
+    /// Generates a vector embedding for the given text.
+    /// </summary>
+    /// <param name="text">Text to embed.</param>
+    /// <param name="inputType">Type of input - Document for indexing, Query for searching.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<float[]?> GenerateEmbeddingAsync(string text, EmbeddingInputType inputType = EmbeddingInputType.Document, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if the embedding service is available and responding.
+    /// </summary>
+    Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Indicates whether the service is properly configured.
+    /// </summary>
+    bool IsConfigured { get; }
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/IServiceLifecycleManager.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/IServiceLifecycleManager.cs
@@ -1,0 +1,13 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Interface for services that need lifecycle management (e.g., starting external dependencies).
+/// Extracted from IEmbeddingService to follow Interface Segregation Principle (ISP).
+/// </summary>
+public interface IServiceLifecycleManager
+{
+    /// <summary>
+    /// Ensures the external service is running and available.
+    /// </summary>
+    Task EnsureRunningAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/IServiceManager.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/IServiceManager.cs
@@ -1,0 +1,23 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Abstraction for managing system services.
+/// Different implementations for different platforms (systemd, Windows Services, etc.).
+/// </summary>
+public interface IServiceManager
+{
+    /// <summary>
+    /// Starts a system service.
+    /// </summary>
+    /// <param name="serviceName">Name of the service to start.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task StartServiceAsync(string serviceName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a system service is running.
+    /// </summary>
+    /// <param name="serviceName">Name of the service to check.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the service is running.</returns>
+    Task<bool> IsServiceRunningAsync(string serviceName, CancellationToken cancellationToken = default);
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/ISummarizationService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/ISummarizationService.cs
@@ -1,0 +1,44 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Service for AI-powered summarization of text content.
+/// </summary>
+public interface ISummarizationService
+{
+    /// <summary>
+    /// Summarizes the given text content.
+    /// </summary>
+    /// <param name="content">Text to summarize.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Summary result with status information.</returns>
+    Task<SummarizationResult> SummarizeAsync(string content, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of a summarization request.
+/// </summary>
+public class SummarizationResult
+{
+    /// <summary>Whether summarization was successful.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>The generated summary, or null if failed.</summary>
+    public string? Summary { get; set; }
+
+    /// <summary>Error message if summarization failed.</summary>
+    public string? Error { get; set; }
+
+    /// <summary>Which provider was used (for logging).</summary>
+    public string? Provider { get; set; }
+
+    /// <summary>Which model was used (for logging).</summary>
+    public string? Model { get; set; }
+
+    /// <summary>Creates a successful result.</summary>
+    public static SummarizationResult Ok(string summary, string provider, string model) =>
+        new() { Success = true, Summary = summary, Provider = provider, Model = model };
+
+    /// <summary>Creates a failed result.</summary>
+    public static SummarizationResult Fail(string error) =>
+        new() { Success = false, Error = error };
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/ITranslationService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/ITranslationService.cs
@@ -1,0 +1,45 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Service for AI-powered translation of text content.
+/// Uses different providers than summarization to spread API usage.
+/// </summary>
+public interface ITranslationService
+{
+    /// <summary>
+    /// Translates the given text to Czech.
+    /// </summary>
+    /// <param name="text">Text to translate (typically an English summary).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Translation result with status information.</returns>
+    Task<TranslationResult> TranslateToCzechAsync(string text, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of a translation request.
+/// </summary>
+public class TranslationResult
+{
+    /// <summary>Whether translation was successful.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>The translated text, or null if failed.</summary>
+    public string? Translation { get; set; }
+
+    /// <summary>Error message if translation failed.</summary>
+    public string? Error { get; set; }
+
+    /// <summary>Which provider was used (for logging).</summary>
+    public string? Provider { get; set; }
+
+    /// <summary>Which model was used (for logging).</summary>
+    public string? Model { get; set; }
+
+    /// <summary>Creates a successful result.</summary>
+    public static TranslationResult Ok(string translation, string provider, string model) =>
+        new() { Success = true, Translation = translation, Provider = provider, Model = model };
+
+    /// <summary>Creates a failed result.</summary>
+    public static TranslationResult Fail(string error) =>
+        new() { Success = false, Error = error };
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/SummarizationSettings.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/SummarizationSettings.cs
@@ -1,0 +1,16 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Settings for summarization behavior.
+/// </summary>
+public class SummarizationSettings
+{
+    /// <summary>Maximum tokens in summary response.</summary>
+    public int MaxTokens { get; set; } = 150;
+
+    /// <summary>Temperature for generation (lower = more deterministic).</summary>
+    public double Temperature { get; set; } = 0.3;
+
+    /// <summary>System prompt for summarization.</summary>
+    public string SystemPrompt { get; set; } = "You are a helpful assistant that summarizes GitHub issues concisely. Provide a 2-3 sentence summary in English that captures the key points.";
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/TranslationSettings.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/TranslationSettings.cs
@@ -1,0 +1,19 @@
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+/// <summary>
+/// Settings for translation behavior.
+/// </summary>
+public class TranslationSettings
+{
+    /// <summary>Maximum tokens in translation response.</summary>
+    public int MaxTokens { get; set; } = 300;
+
+    /// <summary>Temperature for generation (lower = more deterministic).</summary>
+    public double Temperature { get; set; } = 0.2;
+
+    /// <summary>Target language for translation.</summary>
+    public string TargetLanguage { get; set; } = "Czech";
+
+    /// <summary>System prompt for translation (for OpenAI-compatible providers).</summary>
+    public string SystemPrompt { get; set; } = "Translate the following text to Czech. Preserve the meaning and tone. Output only the translation, nothing else.";
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Cohere/CohereEmbeddingService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Cohere/CohereEmbeddingService.cs
@@ -1,0 +1,250 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Cohere;
+
+/// <summary>
+/// Cohere cloud API embedding service implementation with dual API key rotation.
+/// Uses embed-multilingual-v3.0 model which supports Czech and cross-language search.
+/// Implements round-robin key rotation to maximize free tier quota.
+/// </summary>
+public class CohereEmbeddingService : IEmbeddingService
+{
+    private readonly HttpClient _httpClient;
+    private readonly EmbeddingSettings _settings;
+    private readonly ILogger<CohereEmbeddingService> _logger;
+    private readonly IReadOnlyList<string> _apiKeys;
+
+    // Thread-safe counter for round-robin key rotation
+    private long _requestCounter;
+
+    private const string CohereApiUrl = "https://api.cohere.com/v2/embed";
+
+    public CohereEmbeddingService(
+        HttpClient httpClient,
+        IOptions<EmbeddingSettings> settings,
+        ILogger<CohereEmbeddingService> logger)
+    {
+        _httpClient = httpClient;
+        _settings = settings.Value;
+        _logger = logger;
+        _apiKeys = _settings.GetCohereApiKeys();
+
+        if (_apiKeys.Count > 0)
+        {
+            _logger.LogInformation("Cohere embedding service initialized with {KeyCount} API key(s)", _apiKeys.Count);
+        }
+    }
+
+    public bool IsConfigured => _apiKeys.Count > 0;
+
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsConfigured)
+        {
+            return false;
+        }
+
+        try
+        {
+            var embedding = await GenerateEmbeddingAsync("test", EmbeddingInputType.Query, cancellationToken);
+            return embedding != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<float[]?> GenerateEmbeddingAsync(string text, EmbeddingInputType inputType = EmbeddingInputType.Document, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        if (!IsConfigured)
+        {
+            _logger.LogWarning("Cohere API keys are not configured");
+            return null;
+        }
+
+        var inputTypeString = inputType == EmbeddingInputType.Query ? "search_query" : "search_document";
+
+        // Try with round-robin key, then retry with next key on 429
+        var startKeyIndex = GetNextKeyIndex();
+        var triedKeys = new HashSet<int>();
+
+        for (var attempt = 0; attempt < _apiKeys.Count; attempt++)
+        {
+            var keyIndex = (startKeyIndex + attempt) % _apiKeys.Count;
+            if (triedKeys.Contains(keyIndex))
+            {
+                break;
+            }
+            triedKeys.Add(keyIndex);
+
+            var apiKey = _apiKeys[keyIndex];
+            var maskedKey = MaskApiKey(apiKey);
+
+            var result = await TryGenerateEmbeddingAsync(text, inputTypeString, apiKey, maskedKey, cancellationToken);
+
+            if (result.Success)
+            {
+                return result.Embedding;
+            }
+
+            // Only retry with different key on rate limit (429)
+            if (result.StatusCode != 429)
+            {
+                return null;
+            }
+
+            if (attempt < _apiKeys.Count - 1)
+            {
+                var nextKeyIndex = (keyIndex + 1) % _apiKeys.Count;
+                var nextMaskedKey = MaskApiKey(_apiKeys[nextKeyIndex]);
+                _logger.LogWarning("Cohere rate limit: key=...{MaskedKey}, switching to ...{NextMaskedKey}",
+                    maskedKey, nextMaskedKey);
+            }
+        }
+
+        _logger.LogError("All Cohere API keys exhausted (rate limited)");
+        return null;
+    }
+
+    private async Task<(bool Success, float[]? Embedding, int StatusCode)> TryGenerateEmbeddingAsync(
+        string text,
+        string inputType,
+        string apiKey,
+        string maskedKey,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var request = new CohereEmbedRequest
+            {
+                Texts = [text],
+                Model = _settings.CohereModel,
+                InputType = inputType,
+                EmbeddingTypes = ["float"]
+            };
+
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, CohereApiUrl);
+            httpRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+            httpRequest.Content = JsonContent.Create(request);
+
+            var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+            stopwatch.Stop();
+
+            var statusCode = (int)response.StatusCode;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                if (statusCode == 429)
+                {
+                    _logger.LogWarning("Cohere rate limit: key=...{MaskedKey}, status={StatusCode}, latency={Latency}ms",
+                        maskedKey, statusCode, stopwatch.ElapsedMilliseconds);
+                }
+                else
+                {
+                    _logger.LogWarning("Cohere failed: key=...{MaskedKey}, status={StatusCode}, latency={Latency}ms, error={Error}",
+                        maskedKey, statusCode, stopwatch.ElapsedMilliseconds, errorContent);
+                }
+
+                return (false, null, statusCode);
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<CohereEmbedResponse>(cancellationToken);
+
+            if (result?.Embeddings?.Float?.Count > 0)
+            {
+                var embedding = result.Embeddings.Float[0].ToArray();
+
+                _logger.LogInformation("Cohere embed: key=...{MaskedKey}, texts=1, type={InputType}, status={StatusCode}, latency={Latency}ms",
+                    maskedKey, inputType, statusCode, stopwatch.ElapsedMilliseconds);
+
+                return (true, embedding, statusCode);
+            }
+
+            _logger.LogWarning("Cohere response did not contain embeddings: key=...{MaskedKey}", maskedKey);
+            return (false, null, statusCode);
+        }
+        catch (HttpRequestException ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "Cohere connection failed: key=...{MaskedKey}, latency={Latency}ms",
+                maskedKey, stopwatch.ElapsedMilliseconds);
+            return (false, null, 0);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "Cohere error: key=...{MaskedKey}, latency={Latency}ms",
+                maskedKey, stopwatch.ElapsedMilliseconds);
+            return (false, null, 0);
+        }
+    }
+
+    /// <summary>
+    /// Gets the next API key index using round-robin rotation.
+    /// Thread-safe using Interlocked.Increment.
+    /// </summary>
+    private int GetNextKeyIndex()
+    {
+        var count = Interlocked.Increment(ref _requestCounter);
+        return (int)((count - 1) % _apiKeys.Count);
+    }
+
+    /// <summary>
+    /// Masks API key for logging - shows only last 4 characters.
+    /// </summary>
+    private static string MaskApiKey(string apiKey)
+    {
+        if (string.IsNullOrEmpty(apiKey) || apiKey.Length < 4)
+        {
+            return "****";
+        }
+        return apiKey[^4..];
+    }
+
+    // Request/response DTOs for Cohere API v2
+
+    private class CohereEmbedRequest
+    {
+        [JsonPropertyName("texts")]
+        public string[] Texts { get; set; } = [];
+
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = "embed-multilingual-v3.0";
+
+        [JsonPropertyName("input_type")]
+        public string InputType { get; set; } = "search_document";
+
+        [JsonPropertyName("embedding_types")]
+        public string[] EmbeddingTypes { get; set; } = ["float"];
+    }
+
+    private class CohereEmbedResponse
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("embeddings")]
+        public CohereEmbeddings? Embeddings { get; set; }
+    }
+
+    private class CohereEmbeddings
+    {
+        [JsonPropertyName("float")]
+        public List<List<float>>? Float { get; set; }
+    }
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Cohere/CohereTranslationService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Cohere/CohereTranslationService.cs
@@ -1,0 +1,173 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Cohere;
+
+/// <summary>
+/// Cohere-based translation service using specialized translation models.
+/// </summary>
+public class CohereTranslationService : ITranslationService
+{
+    private readonly HttpClient _httpClient;
+    private readonly AiProvidersSettings _providers;
+    private readonly ILogger<CohereTranslationService> _logger;
+
+    // Thread-safe key rotation
+    private static int _keyIndex;
+
+    public CohereTranslationService(
+        HttpClient httpClient,
+        IOptions<AiProvidersSettings> providers,
+        ILogger<CohereTranslationService> logger)
+    {
+        _httpClient = httpClient;
+        _providers = providers.Value;
+        _logger = logger;
+    }
+
+    public async Task<TranslationResult> TranslateToCzechAsync(string text, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return TranslationResult.Fail("No text to translate");
+        }
+
+        var cohereKeys = _providers.Cohere.Keys.Where(k => !string.IsNullOrEmpty(k)).ToList();
+        if (cohereKeys.Count == 0)
+        {
+            _logger.LogDebug("No Cohere API keys configured");
+            return TranslationResult.Fail("No Cohere keys");
+        }
+
+        var models = _providers.Cohere.TranslationModels;
+        if (models.Length == 0)
+        {
+            models = ["command-a-translate-08-2025", "c4ai-aya-expanse-32b"];
+        }
+
+        // Try each key/model combination
+        foreach (var model in models)
+        {
+            var keyIndex = Interlocked.Increment(ref _keyIndex) % cohereKeys.Count;
+            var apiKey = cohereKeys[keyIndex];
+
+            try
+            {
+                var result = await CallCohereAsync(apiKey, model, text, cancellationToken);
+                if (result.Success)
+                {
+                    return result;
+                }
+                _logger.LogWarning("Cohere translation failed with {Model}: {Error}", model, result.Error);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Exception during Cohere translation with {Model}", model);
+            }
+        }
+
+        return TranslationResult.Fail("All Cohere attempts failed");
+    }
+
+    private async Task<TranslationResult> CallCohereAsync(
+        string apiKey,
+        string model,
+        string text,
+        CancellationToken cancellationToken)
+    {
+        // Cohere v2 chat API format
+        var request = new CohereRequest
+        {
+            Model = model,
+            Messages =
+            [
+                new CohereMessage
+                {
+                    Role = "user",
+                    Content = $"Translate the following text to Czech. Output only the translation, nothing else.\n\n{text}"
+                }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(request, CohereTranslationJsonContext.Default.CohereRequest);
+        var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _providers.Cohere.Endpoint + "chat");
+        httpRequest.Content = httpContent;
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        _logger.LogDebug("Trying Cohere translation with {Model}", model);
+
+        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            return TranslationResult.Fail($"HTTP {(int)response.StatusCode}: {errorBody}");
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        var cohereResponse = JsonSerializer.Deserialize(responseBody, CohereTranslationJsonContext.Default.CohereResponse);
+
+        var translation = cohereResponse?.Message?.Content?.FirstOrDefault()?.Text;
+
+        if (string.IsNullOrEmpty(translation))
+        {
+            return TranslationResult.Fail("Empty response from Cohere");
+        }
+
+        _logger.LogInformation("Translation successful with Cohere/{Model}", model);
+        return TranslationResult.Ok(translation, "Cohere", model);
+    }
+}
+
+// Cohere API models
+internal class CohereRequest
+{
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = string.Empty;
+
+    [JsonPropertyName("messages")]
+    public CohereMessage[] Messages { get; set; } = [];
+}
+
+internal class CohereMessage
+{
+    [JsonPropertyName("role")]
+    public string Role { get; set; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+}
+
+internal class CohereResponse
+{
+    [JsonPropertyName("message")]
+    public CohereResponseMessage? Message { get; set; }
+}
+
+internal class CohereResponseMessage
+{
+    [JsonPropertyName("content")]
+    public CohereContentItem[]? Content { get; set; }
+}
+
+internal class CohereContentItem
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+}
+
+[JsonSerializable(typeof(CohereRequest))]
+[JsonSerializable(typeof(CohereResponse))]
+internal partial class CohereTranslationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Cohere/Olbrasoft.GitHub.Issues.Text.Transformation.Cohere.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Cohere/Olbrasoft.GitHub.Issues.Text.Transformation.Cohere.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Ollama/Olbrasoft.GitHub.Issues.Text.Transformation.Ollama.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Ollama/Olbrasoft.GitHub.Issues.Text.Transformation.Ollama.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Ollama/OllamaEmbeddingService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Ollama/OllamaEmbeddingService.cs
@@ -1,0 +1,128 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.Ollama;
+
+/// <summary>
+/// Ollama-based embedding service implementation.
+/// Implements both IEmbeddingService (core functionality) and IServiceLifecycleManager (Ollama startup).
+/// Uses IServiceManager for testable service management (no direct Process.Start calls).
+/// </summary>
+public class OllamaEmbeddingService : IEmbeddingService, IServiceLifecycleManager
+{
+    private readonly HttpClient _httpClient;
+    private readonly IServiceManager _serviceManager;
+    private readonly EmbeddingSettings _settings;
+    private readonly ILogger<OllamaEmbeddingService> _logger;
+
+    private const string OllamaServiceName = "ollama";
+
+    public OllamaEmbeddingService(
+        HttpClient httpClient,
+        IServiceManager serviceManager,
+        IOptions<EmbeddingSettings> settings,
+        ILogger<OllamaEmbeddingService> logger)
+    {
+        _httpClient = httpClient;
+        _serviceManager = serviceManager;
+        _settings = settings.Value;
+        _logger = logger;
+
+        _httpClient.BaseAddress = new Uri(_settings.BaseUrl);
+    }
+
+    public bool IsConfigured => !string.IsNullOrEmpty(_settings.BaseUrl);
+
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync("/api/tags", cancellationToken);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task EnsureRunningAsync(CancellationToken cancellationToken = default)
+    {
+        if (await IsAvailableAsync(cancellationToken))
+        {
+            _logger.LogInformation("Ollama is already running");
+            return;
+        }
+
+        _logger.LogInformation("Ollama is not running. Starting Ollama service...");
+
+        await _serviceManager.StartServiceAsync(OllamaServiceName, cancellationToken);
+
+        // Wait for Ollama to be ready (retry loop with HTTP health check)
+        for (int i = 0; i < _settings.MaxStartupRetries; i++)
+        {
+            if (await IsAvailableAsync(cancellationToken))
+            {
+                _logger.LogInformation("Ollama started successfully");
+                return;
+            }
+            await Task.Delay(_settings.StartupRetryDelayMs, cancellationToken);
+        }
+
+        var totalWaitSeconds = _settings.MaxStartupRetries * _settings.StartupRetryDelayMs / 1000;
+        throw new InvalidOperationException($"Failed to start Ollama after {totalWaitSeconds} seconds");
+    }
+
+    public async Task<float[]?> GenerateEmbeddingAsync(string text, EmbeddingInputType inputType = EmbeddingInputType.Document, CancellationToken cancellationToken = default)
+    {
+        // Ollama doesn't distinguish between document and query embeddings - parameter ignored
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        try
+        {
+            var request = new
+            {
+                model = _settings.Model,
+                prompt = text
+            };
+
+            var response = await _httpClient.PostAsJsonAsync("/api/embeddings", request, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Ollama API returned {StatusCode}", response.StatusCode);
+                return null;
+            }
+
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+
+            if (json.TryGetProperty("embedding", out var embeddingElement))
+            {
+                var floats = embeddingElement.EnumerateArray()
+                    .Select(e => e.GetSingle())
+                    .ToArray();
+
+                return floats;
+            }
+
+            _logger.LogWarning("Ollama response did not contain embedding property");
+            return null;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Failed to connect to Ollama at {BaseUrl}", _settings.BaseUrl);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error generating embedding");
+            return null;
+        }
+    }
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible/Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible/Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible/OpenAICompatibleSummarizationService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible/OpenAICompatibleSummarizationService.cs
@@ -1,0 +1,271 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible;
+
+/// <summary>
+/// AI summarization service with 3-level rotation: Provider → Key → Model.
+/// Rotation order cycles through all combinations to maximize free tier usage.
+/// </summary>
+public class OpenAICompatibleSummarizationService : ISummarizationService
+{
+    private readonly HttpClient _httpClient;
+    private readonly AiProvidersSettings _providers;
+    private readonly SummarizationSettings _summarization;
+    private readonly ILogger<OpenAICompatibleSummarizationService> _logger;
+
+    // Static rotation state - persists across all instances (service can be transient/scoped)
+    // Thread-safe with Interlocked
+    private static int _rotationIndex;
+
+    // Pre-built list of all provider/key/model combinations
+    private readonly List<ProviderKeyModel> _combinations;
+
+    public OpenAICompatibleSummarizationService(
+        HttpClient httpClient,
+        IOptions<AiProvidersSettings> providers,
+        IOptions<SummarizationSettings> summarization,
+        ILogger<OpenAICompatibleSummarizationService> logger)
+    {
+        _httpClient = httpClient;
+        _providers = providers.Value;
+        _summarization = summarization.Value;
+        _logger = logger;
+
+        _combinations = BuildCombinations();
+    }
+
+    /// <summary>
+    /// Builds all provider/key/model combinations in rotation order.
+    /// Order: For each model level, cycle through (Cerebras+Key1, Groq+Key1, Cerebras+Key2, Groq+Key2).
+    /// </summary>
+    private List<ProviderKeyModel> BuildCombinations()
+    {
+        var combinations = new List<ProviderKeyModel>();
+
+        var cerebrasKeys = _providers.Cerebras.Keys.Where(k => !string.IsNullOrEmpty(k)).ToList();
+        var groqKeys = _providers.Groq.Keys.Where(k => !string.IsNullOrEmpty(k)).ToList();
+        var cerebrasModels = _providers.Cerebras.Models;
+        var groqModels = _providers.Groq.Models;
+
+        var maxModelIndex = Math.Max(cerebrasModels.Length, groqModels.Length);
+
+        for (var modelIndex = 0; modelIndex < maxModelIndex; modelIndex++)
+        {
+            var maxKeyIndex = Math.Max(cerebrasKeys.Count, groqKeys.Count);
+
+            for (var keyIndex = 0; keyIndex < maxKeyIndex; keyIndex++)
+            {
+                // Cerebras with current key and model
+                if (keyIndex < cerebrasKeys.Count && modelIndex < cerebrasModels.Length)
+                {
+                    combinations.Add(new ProviderKeyModel(
+                        "Cerebras",
+                        _providers.Cerebras.Endpoint,
+                        cerebrasKeys[keyIndex],
+                        cerebrasModels[modelIndex]));
+                }
+
+                // Groq with current key and model
+                if (keyIndex < groqKeys.Count && modelIndex < groqModels.Length)
+                {
+                    combinations.Add(new ProviderKeyModel(
+                        "Groq",
+                        _providers.Groq.Endpoint,
+                        groqKeys[keyIndex],
+                        groqModels[keyIndex]));
+                }
+            }
+        }
+
+        _logger.LogInformation("Built {Count} provider/key/model combinations for rotation", combinations.Count);
+        return combinations;
+    }
+
+    public async Task<SummarizationResult> SummarizeAsync(string content, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return SummarizationResult.Fail("No content to summarize");
+        }
+
+        if (_combinations.Count == 0)
+        {
+            _logger.LogWarning("No AI providers configured for summarization");
+            return SummarizationResult.Fail("No AI providers configured");
+        }
+
+        // Try each combination starting from current rotation index
+        var startIndex = GetAndAdvanceRotationIndex();
+        var triedCount = 0;
+
+        while (triedCount < _combinations.Count)
+        {
+            var index = (startIndex + triedCount) % _combinations.Count;
+            var combo = _combinations[index];
+
+            try
+            {
+                var result = await TrySummarizeAsync(combo, content, cancellationToken);
+                if (result.Success)
+                {
+                    return result;
+                }
+
+                _logger.LogWarning("Summarization failed with {Provider}/{Model}: {Error}",
+                    combo.ProviderName, combo.Model, result.Error);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Exception during summarization with {Provider}/{Model}",
+                    combo.ProviderName, combo.Model);
+            }
+
+            triedCount++;
+        }
+
+        return SummarizationResult.Fail("All providers failed");
+    }
+
+    private int GetAndAdvanceRotationIndex()
+    {
+        // Thread-safe increment without lock
+        var count = Math.Max(1, _combinations.Count);
+        var newIndex = Interlocked.Increment(ref _rotationIndex);
+        return (newIndex - 1) % count; // -1 because Increment returns NEW value
+    }
+
+    private async Task<SummarizationResult> TrySummarizeAsync(
+        ProviderKeyModel combo,
+        string content,
+        CancellationToken cancellationToken)
+    {
+        var request = new OpenAiRequest
+        {
+            Model = combo.Model,
+            Messages =
+            [
+                new OpenAiMessage { Role = "system", Content = _summarization.SystemPrompt },
+                new OpenAiMessage { Role = "user", Content = $"Summarize this GitHub issue:\n\n{content}" }
+            ],
+            MaxTokens = _summarization.MaxTokens,
+            Temperature = _summarization.Temperature
+        };
+
+        var json = JsonSerializer.Serialize(request, SummarizationJsonContext.Default.OpenAiRequest);
+        var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, combo.Endpoint + "chat/completions");
+        httpRequest.Content = httpContent;
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", combo.ApiKey);
+
+        _logger.LogDebug("Trying summarization with {Provider}/{Model}", combo.ProviderName, combo.Model);
+
+        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            return SummarizationResult.Fail($"HTTP {(int)response.StatusCode}: {errorBody}");
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        var openAiResponse = JsonSerializer.Deserialize(responseBody, SummarizationJsonContext.Default.OpenAiResponse);
+
+        var summary = openAiResponse?.Choices?.FirstOrDefault()?.Message?.Content;
+
+        if (string.IsNullOrEmpty(summary))
+        {
+            return SummarizationResult.Fail("Empty response from API");
+        }
+
+        // Strip <think>...</think> tags from chain-of-thought models (e.g., qwen-3)
+        summary = StripThinkingTags(summary);
+
+        // If stripping resulted in empty content, model was truncated mid-thinking
+        if (string.IsNullOrWhiteSpace(summary))
+        {
+            _logger.LogWarning("Summary empty after stripping think tags - response was likely truncated");
+            return SummarizationResult.Fail("Response truncated (increase MaxTokens)");
+        }
+
+        _logger.LogInformation("Summarization successful with {Provider}/{Model}", combo.ProviderName, combo.Model);
+        return SummarizationResult.Ok(summary, combo.ProviderName, combo.Model);
+    }
+
+    private record ProviderKeyModel(string ProviderName, string Endpoint, string ApiKey, string Model);
+
+    /// <summary>
+    /// Strips &lt;think&gt;...&lt;/think&gt; tags from chain-of-thought model outputs.
+    /// Also handles truncated think blocks that never close.
+    /// </summary>
+    private static string StripThinkingTags(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+            return content;
+
+        // Remove complete <think>...</think> blocks (including multiline)
+        var result = System.Text.RegularExpressions.Regex.Replace(
+            content,
+            @"<think>[\s\S]*?</think>",
+            string.Empty,
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        // Handle truncated think block (starts with <think> but never closes)
+        // If content still starts with <think> (truncated response), return empty string
+        if (result.TrimStart().StartsWith("<think>", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        return result.Trim();
+    }
+}
+
+// OpenAI-compatible API models with source generation for AOT compatibility
+internal class OpenAiRequest
+{
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = string.Empty;
+
+    [JsonPropertyName("messages")]
+    public OpenAiMessage[] Messages { get; set; } = [];
+
+    [JsonPropertyName("max_tokens")]
+    public int MaxTokens { get; set; }
+
+    [JsonPropertyName("temperature")]
+    public double Temperature { get; set; }
+}
+
+internal class OpenAiMessage
+{
+    [JsonPropertyName("role")]
+    public string Role { get; set; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+}
+
+internal class OpenAiResponse
+{
+    [JsonPropertyName("choices")]
+    public OpenAiChoice[]? Choices { get; set; }
+}
+
+internal class OpenAiChoice
+{
+    [JsonPropertyName("message")]
+    public OpenAiMessage? Message { get; set; }
+}
+
+[JsonSerializable(typeof(OpenAiRequest))]
+[JsonSerializable(typeof(OpenAiResponse))]
+internal partial class SummarizationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible/OpenAICompatibleTranslationService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible/OpenAICompatibleTranslationService.cs
@@ -1,0 +1,225 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+namespace Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible;
+
+/// <summary>
+/// OpenAI-compatible translation service using models with Czech support (e.g., qwen-3-32b).
+/// </summary>
+public class OpenAICompatibleTranslationService : ITranslationService
+{
+    private readonly HttpClient _httpClient;
+    private readonly AiProvidersSettings _providers;
+    private readonly TranslationSettings _translation;
+    private readonly ILogger<OpenAICompatibleTranslationService> _logger;
+
+    // Thread-safe rotation
+    private static int _fallbackIndex;
+
+    // Pre-built fallback combinations (Cerebras/Groq with Czech-capable models)
+    private readonly List<TranslationProvider> _providers_list;
+
+    public OpenAICompatibleTranslationService(
+        HttpClient httpClient,
+        IOptions<AiProvidersSettings> providers,
+        IOptions<TranslationSettings> translation,
+        ILogger<OpenAICompatibleTranslationService> logger)
+    {
+        _httpClient = httpClient;
+        _providers = providers.Value;
+        _translation = translation.Value;
+        _logger = logger;
+
+        _providers_list = BuildProvidersList();
+    }
+
+    private List<TranslationProvider> BuildProvidersList()
+    {
+        var list = new List<TranslationProvider>();
+
+        // Add Cerebras with Czech-capable models (qwen-3-32b has official Czech support)
+        var cerebrasKeys = _providers.Cerebras.Keys.Where(k => !string.IsNullOrEmpty(k)).ToList();
+        foreach (var key in cerebrasKeys)
+        {
+            // qwen-3-32b officially supports 119 languages including Czech
+            list.Add(new TranslationProvider("Cerebras", _providers.Cerebras.Endpoint, key, "qwen-3-32b"));
+        }
+
+        // Add Groq with Czech-capable models
+        var groqKeys = _providers.Groq.Keys.Where(k => !string.IsNullOrEmpty(k)).ToList();
+        foreach (var key in groqKeys)
+        {
+            list.Add(new TranslationProvider("Groq", _providers.Groq.Endpoint, key, "qwen/qwen3-32b"));
+        }
+
+        _logger.LogInformation("Built {Count} translation providers", list.Count);
+        return list;
+    }
+
+    public async Task<TranslationResult> TranslateToCzechAsync(string text, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return TranslationResult.Fail("No text to translate");
+        }
+
+        if (_providers_list.Count == 0)
+        {
+            return TranslationResult.Fail("No providers configured");
+        }
+
+        var startIndex = Interlocked.Increment(ref _fallbackIndex) % _providers_list.Count;
+        var tried = 0;
+
+        while (tried < _providers_list.Count)
+        {
+            var index = (startIndex + tried) % _providers_list.Count;
+            var provider = _providers_list[index];
+
+            try
+            {
+                var result = await CallOpenAiCompatibleAsync(provider, text, cancellationToken);
+                if (result.Success)
+                {
+                    return result;
+                }
+                _logger.LogWarning("Translation failed with {Provider}/{Model}: {Error}",
+                    provider.Name, provider.Model, result.Error);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Exception during translation with {Provider}/{Model}",
+                    provider.Name, provider.Model);
+            }
+
+            tried++;
+        }
+
+        return TranslationResult.Fail("All translation providers failed");
+    }
+
+    private async Task<TranslationResult> CallOpenAiCompatibleAsync(
+        TranslationProvider provider,
+        string text,
+        CancellationToken cancellationToken)
+    {
+        var request = new OpenAiTranslationRequest
+        {
+            Model = provider.Model,
+            Messages =
+            [
+                new OpenAiTranslationMessage { Role = "system", Content = _translation.SystemPrompt },
+                new OpenAiTranslationMessage { Role = "user", Content = text }
+            ],
+            MaxTokens = _translation.MaxTokens,
+            Temperature = _translation.Temperature
+        };
+
+        var json = JsonSerializer.Serialize(request, TranslationJsonContext.Default.OpenAiTranslationRequest);
+        var httpContent = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, provider.Endpoint + "chat/completions");
+        httpRequest.Content = httpContent;
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", provider.ApiKey);
+
+        _logger.LogDebug("Trying translation with {Provider}/{Model}", provider.Name, provider.Model);
+
+        using var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            return TranslationResult.Fail($"HTTP {(int)response.StatusCode}: {errorBody}");
+        }
+
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+        var openAiResponse = JsonSerializer.Deserialize(responseBody, TranslationJsonContext.Default.OpenAiTranslationResponse);
+
+        var translation = openAiResponse?.Choices?.FirstOrDefault()?.Message?.Content;
+
+        if (string.IsNullOrEmpty(translation))
+        {
+            return TranslationResult.Fail("Empty response from API");
+        }
+
+        // Strip <think>...</think> tags from chain-of-thought models
+        translation = StripThinkingTags(translation);
+
+        if (string.IsNullOrWhiteSpace(translation))
+        {
+            return TranslationResult.Fail("Response truncated (increase MaxTokens)");
+        }
+
+        _logger.LogInformation("Translation successful with {Provider}/{Model}", provider.Name, provider.Model);
+        return TranslationResult.Ok(translation, provider.Name, provider.Model);
+    }
+
+    private static string StripThinkingTags(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+            return content;
+
+        var result = System.Text.RegularExpressions.Regex.Replace(
+            content,
+            @"<think>[\s\S]*?</think>",
+            string.Empty,
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        if (result.TrimStart().StartsWith("<think>", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        return result.Trim();
+    }
+
+    private record TranslationProvider(string Name, string Endpoint, string ApiKey, string Model);
+}
+
+// OpenAI-compatible models for translation
+internal class OpenAiTranslationRequest
+{
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = string.Empty;
+
+    [JsonPropertyName("messages")]
+    public OpenAiTranslationMessage[] Messages { get; set; } = [];
+
+    [JsonPropertyName("max_tokens")]
+    public int MaxTokens { get; set; }
+
+    [JsonPropertyName("temperature")]
+    public double Temperature { get; set; }
+}
+
+internal class OpenAiTranslationMessage
+{
+    [JsonPropertyName("role")]
+    public string Role { get; set; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+}
+
+internal class OpenAiTranslationResponse
+{
+    [JsonPropertyName("choices")]
+    public OpenAiTranslationChoice[]? Choices { get; set; }
+}
+
+internal class OpenAiTranslationChoice
+{
+    [JsonPropertyName("message")]
+    public OpenAiTranslationMessage? Message { get; set; }
+}
+
+[JsonSerializable(typeof(OpenAiTranslationRequest))]
+[JsonSerializable(typeof(OpenAiTranslationResponse))]
+internal partial class TranslationJsonContext : JsonSerializerContext
+{
+}

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation/Olbrasoft.GitHub.Issues.Text.Transformation.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation/Olbrasoft.GitHub.Issues.Text.Transformation.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Phase 1 of #136 - Create dedicated Text.Transformation projects.

## Changes
- Added 5 new projects for text transformation services:
  - `Text.Transformation.Abstractions` - Interfaces (IEmbeddingService, ISummarizationService, ITranslationService)
  - `Text.Transformation` - Core utilities
  - `Text.Transformation.Ollama` - OllamaEmbeddingService
  - `Text.Transformation.Cohere` - CohereEmbeddingService, CohereTranslationService
  - `Text.Transformation.OpenAICompatible` - OpenAICompatibleSummarizationService, OpenAICompatibleTranslationService
- Settings classes for configuration

## Note
This is Phase 1 - creating the new structure with duplicated code.
Phase 2 (updating existing code to use these projects) will be done in follow-up PR.

## Testing
- Build: ✅ Passes
- Tests: ✅ 134 tests pass