### PR TITLE
fix(#166): Fix failing CI/CD pipeline - DeepL test assertion

### DIFF
--- a/test/Olbrasoft.Text.Translation.DeepL.Tests/DeepLTranslatorTests.cs
+++ b/test/Olbrasoft.Text.Translation.DeepL.Tests/DeepLTranslatorTests.cs
@@ -117,7 +117,7 @@ public class DeepLTranslatorTests
 
         // Assert
         Assert.False(result.Success);
-        Assert.Contains("401", result.Error);
+        Assert.Contains("Unauthorized", result.Error);
         Assert.Equal("DeepL", result.Provider);
     }
 }


### PR DESCRIPTION
## Summary

Fix the failing GitHub Actions CI/CD pipeline by correcting the DeepL test assertion.

## Problem

The test `DeepLTranslatorTests.TranslateAsync_ApiError_ReturnsFailure` was expecting "401" in the error message, but the actual error format is "DeepL API error: Unauthorized".

## Solution

Changed the assertion from:
```csharp
Assert.Contains("401", result.Error);
```
to:
```csharp
Assert.Contains("Unauthorized", result.Error);
```

## Testing

- ✅ All 217 tests pass locally
- ✅ Build successful

## Related

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)