### PR TITLE
feat(#173): Implement Phase 2 - Fetch GitHub bodies for visible issues

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
@@ -86,6 +86,7 @@ public static class ServiceExtensions
 
         // SignalR notifiers
         services.AddScoped<ISummaryNotifier, SignalRSummaryNotifier>();
+        services.AddScoped<IBodyNotifier, SignalRBodyNotifier>();
         services.AddScoped<ITitleTranslationNotifier, SignalRTitleTranslationNotifier>();
         services.AddScoped<ITitleTranslationService, TitleTranslationService>();
 

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Hubs/SignalRBodyNotifier.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Hubs/SignalRBodyNotifier.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.SignalR;
+using Olbrasoft.GitHub.Issues.Business;
+
+namespace Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Hubs;
+
+/// <summary>
+/// SignalR implementation of IBodyNotifier.
+/// Sends issue body preview to subscribed clients when fetched from GitHub.
+/// </summary>
+public class SignalRBodyNotifier : IBodyNotifier
+{
+    private readonly IHubContext<IssueUpdatesHub> _hubContext;
+    private readonly ILogger<SignalRBodyNotifier> _logger;
+
+    public SignalRBodyNotifier(
+        IHubContext<IssueUpdatesHub> hubContext,
+        ILogger<SignalRBodyNotifier> logger)
+    {
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    public async Task NotifyBodyReceivedAsync(BodyNotificationDto notification, CancellationToken cancellationToken = default)
+    {
+        var groupName = $"issue-{notification.IssueId}";
+
+        _logger.LogDebug(
+            "[SignalR] Broadcasting BodyReceived to group {Group} for issue {Id}",
+            groupName, notification.IssueId);
+
+        await _hubContext.Clients.Group(groupName).SendAsync(
+            "BodyReceived",
+            new
+            {
+                issueId = notification.IssueId,
+                bodyPreview = notification.BodyPreview
+            },
+            cancellationToken);
+    }
+}

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/css/site.css
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/css/site.css
@@ -980,6 +980,26 @@ footer {
     }
 }
 
+/* Body preview received animation */
+.body-preview.body-received {
+    animation: body-highlight 2s ease-out;
+}
+
+@keyframes body-highlight {
+    0% {
+        background-color: #fff3cd;
+        padding: 0.5rem;
+        border-radius: 4px;
+    }
+    50% {
+        background-color: #fef9e7;
+    }
+    100% {
+        background-color: transparent;
+        padding: 0;
+    }
+}
+
 /* Issue labels (GitHub-style badges) */
 .label-badge {
     display: inline-block;

--- a/src/Olbrasoft.GitHub.Issues.Business/IBodyNotifier.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/IBodyNotifier.cs
@@ -1,0 +1,30 @@
+namespace Olbrasoft.GitHub.Issues.Business;
+
+/// <summary>
+/// DTO for body notification sent via SignalR.
+/// </summary>
+/// <param name="IssueId">Database issue ID</param>
+/// <param name="BodyPreview">First N characters of issue body</param>
+public record BodyNotificationDto(
+    int IssueId,
+    string BodyPreview);
+
+/// <summary>
+/// Interface for notifying clients when issue body is fetched.
+/// </summary>
+public interface IBodyNotifier
+{
+    /// <summary>
+    /// Sends body preview to subscribed clients via SignalR.
+    /// </summary>
+    Task NotifyBodyReceivedAsync(BodyNotificationDto notification, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Null implementation for when SignalR is not configured.
+/// </summary>
+public class NullBodyNotifier : IBodyNotifier
+{
+    public Task NotifyBodyReceivedAsync(BodyNotificationDto notification, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/src/Olbrasoft.GitHub.Issues.Business/IIssueDetailService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/IIssueDetailService.cs
@@ -27,6 +27,13 @@ public interface IIssueDetailService
     /// <param name="language">Language preference: "en" (English only), "cs" (Czech only), "both" (English first, then Czech)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     Task GenerateSummaryAsync(int issueId, string language, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches bodies for multiple issues from GitHub GraphQL API and sends previews via SignalR.
+    /// </summary>
+    /// <param name="issueIds">List of database issue IDs to fetch bodies for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task FetchBodiesAsync(IEnumerable<int> issueIds, CancellationToken cancellationToken = default);
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Implements Phase 2 of progressive loading: fetch GitHub issue bodies for visible issues
- Uses Intersection Observer API to detect when issues become visible in viewport
- Fetches bodies from GitHub GraphQL API and sends previews via SignalR
- Includes markdown stripping for clean body previews

## Changes
- **New files:**
  - `IBodyNotifier.cs` - Interface and DTO for body notifications
  - `SignalRBodyNotifier.cs` - SignalR implementation for body notifications
- **Modified files:**
  - `IIssueDetailService.cs` - Added `FetchBodiesAsync` method
  - `IssueDetailService.cs` - Implemented body fetching with markdown stripping
  - `IssueEndpoints.cs` - Added `/api/issues/fetch-bodies` API endpoint
  - `ServiceExtensions.cs` - Registered `IBodyNotifier` in DI
  - `issue-updates.js` - Added Intersection Observer and body handlers
  - `site.css` - Added body-received animation

## Test plan
- [ ] Verify build passes
- [ ] Verify all 178 tests pass
- [ ] Test body fetching in browser with console logging
- [ ] Verify Intersection Observer triggers for visible issues
- [ ] Verify SignalR body notifications arrive and update DOM

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)