### PR TITLE
feat(#174): Implement Phase 3 - LLM summarization with SignalR updates

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/js/issue-updates.js
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/js/issue-updates.js
@@ -320,19 +320,19 @@
             return;
         }
 
-        console.log('[issue-updates] Fetching bodies for issues:', issueIds);
+        console.log('[issue-updates] Fetching bodies and summaries for issues:', issueIds, 'language:', selectedLanguage);
 
-        // Fire-and-forget API call to fetch bodies
+        // Fire-and-forget API call to fetch bodies and generate summaries
         fetch('/api/issues/fetch-bodies', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({ issueIds: issueIds })
+            body: JSON.stringify({ issueIds: issueIds, language: selectedLanguage })
         })
         .then(function(response) {
             if (response.ok) {
-                console.log('[issue-updates] Body fetch triggered for', issueIds.length, 'issues');
+                console.log('[issue-updates] Body fetch and summarization triggered for', issueIds.length, 'issues');
             } else {
                 console.error('[issue-updates] Failed to trigger body fetch:', response.status);
                 // Remove from fetched set so we can retry

--- a/src/Olbrasoft.GitHub.Issues.Business/IIssueDetailService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/IIssueDetailService.cs
@@ -30,10 +30,21 @@ public interface IIssueDetailService
 
     /// <summary>
     /// Fetches bodies for multiple issues from GitHub GraphQL API and sends previews via SignalR.
+    /// Also triggers AI summarization for each issue with a body.
     /// </summary>
     /// <param name="issueIds">List of database issue IDs to fetch bodies for.</param>
+    /// <param name="language">Language preference for summaries: "en", "cs", or "both".</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task FetchBodiesAsync(IEnumerable<int> issueIds, CancellationToken cancellationToken = default);
+    Task FetchBodiesAsync(IEnumerable<int> issueIds, string language = "en", CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates AI summary from a pre-fetched body and sends notification via SignalR.
+    /// </summary>
+    /// <param name="issueId">Database issue ID</param>
+    /// <param name="body">Pre-fetched issue body text</param>
+    /// <param name="language">Language preference: "en" (English only), "cs" (Czech only), "both" (English first, then Czech)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task GenerateSummaryFromBodyAsync(int issueId, string body, string language, CancellationToken cancellationToken = default);
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Integrates LLM summarization into the body fetch flow
- After bodies are fetched from GitHub GraphQL, summaries are generated automatically
- Summaries sent via SignalR to update ALL loaded DOM nodes (not just visible)

## Changes
- **IIssueDetailService.cs**:
  - Added `GenerateSummaryFromBodyAsync` method for direct body input
  - Updated `FetchBodiesAsync` signature to accept language parameter
- **IssueDetailService.cs**:
  - Implemented `GenerateSummaryFromBodyAsync` to avoid re-fetching bodies
  - Modified `FetchBodiesAsync` to trigger summarization after body previews
  - Summaries generated sequentially to avoid LLM overload
- **IssueEndpoints.cs**:
  - Updated `/api/issues/fetch-bodies` to accept language parameter
  - Maps language to summary format (en → "en", cs/de → "both")
- **issue-updates.js**:
  - Updated `fetchBodiesForIssues` to pass selectedLanguage

## Flow
1. Body arrives from GitHub GraphQL
2. Body preview sent via SignalR
3. LLM generates English summary
4. English summary sent via SignalR
5. If language != "en": translate and send translated summary

## Test plan
- [ ] Verify build passes
- [ ] Verify all 217 tests pass
- [ ] Test body fetch triggers summarization
- [ ] Verify English summaries arrive via SignalR
- [ ] Verify translated summaries arrive (if non-English language)
- [ ] Verify ALL loaded DOM nodes update (not just visible)

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)