### PR TITLE
refactor: remove old LLM translation, use shared language session key

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
@@ -72,10 +72,8 @@ public static class ServiceExtensions
         // AI services - Text.Transformation
         services.AddHttpClient<ISummarizationService, OpenAICompatibleSummarizationService>()
             .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(60));
-        services.AddHttpClient<ITranslationService, CohereTranslationService>()
-            .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(60));
 
-        // Dedicated translation service (DeepL) for title translations
+        // Translation service (DeepL) for title and summary translations
         services.AddHttpClient<ITranslator, DeepLTranslator>()
             .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(30));
 

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Issue/Detail.cshtml
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Issue/Detail.cshtml
@@ -45,7 +45,7 @@
                 </div>
             }
 
-            <div id="ai-summary-container" data-issue-id="@Model.Issue.Id" data-summary-pending="@Model.SummaryPending.ToString().ToLower()" data-summary-language="@Model.SummaryLanguage">
+            <div id="ai-summary-container" data-issue-id="@Model.Issue.Id" data-summary-pending="@Model.SummaryPending.ToString().ToLower()" data-summary-language="@Model.Language">
                 @if (!string.IsNullOrEmpty(Model.Summary))
                 {
                     <div class="ai-summary">

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Issue/Detail.cshtml.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Issue/Detail.cshtml.cs
@@ -10,7 +10,7 @@ namespace Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Pages.Issue;
 /// </summary>
 public class DetailModel : PageModel
 {
-    private const string SessionKeyTranslateToCzech = "Search.TranslateToCzech";
+    private const string SessionKeyLanguage = "Search.Language";
     private readonly IIssueDetailService _issueDetailService;
 
     public DetailModel(IIssueDetailService issueDetailService)
@@ -47,17 +47,17 @@ public class DetailModel : PageModel
     public string SafeReturnUrl => string.IsNullOrWhiteSpace(ReturnUrl) ? "/" : ReturnUrl;
 
     /// <summary>
-    /// Language preference for summaries: "both" (default, when TranslateToCzech=true) or "en" (when false).
-    /// Read from session, set by Index page checkbox.
+    /// Selected language for translations (en, de, cs).
+    /// Read from session, shared with Index page language selector.
     /// </summary>
-    public string SummaryLanguage { get; private set; } = "both";
+    public string Language { get; private set; } = "cs";
 
     public async Task<IActionResult> OnGetAsync(int id, CancellationToken cancellationToken)
     {
-        // Read TranslateToCzech preference from session (default: true = "both")
-        var translateToCzechValue = HttpContext.Session.GetInt32(SessionKeyTranslateToCzech);
-        var translateToCzech = translateToCzechValue == null || translateToCzechValue.Value == 1;
-        SummaryLanguage = translateToCzech ? "both" : "en";
+        // Read language preference from session (default: "cs" - Czech)
+        var savedLanguage = HttpContext.Session.GetString(SessionKeyLanguage);
+        if (!string.IsNullOrEmpty(savedLanguage) && IsValidLanguage(savedLanguage))
+            Language = savedLanguage;
 
         var result = await _issueDetailService.GetIssueDetailAsync(id, cancellationToken);
 
@@ -75,4 +75,7 @@ public class DetailModel : PageModel
 
         return Page();
     }
+
+    private static bool IsValidLanguage(string? language)
+        => language is "en" or "de" or "cs";
 }


### PR DESCRIPTION
## Summary
- Remove `ITranslationService` (Cohere LLM) registration from `ServiceExtensions`
- Update `Detail.cshtml.cs` to use `SessionKeyLanguage` (shared with Index page)
- Rename `SummaryLanguage` property to `Language` for consistency
- Add `IsValidLanguage` helper method

This enables the language selector in the header to be a website-wide setting, applying to both search results and issue detail pages.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)