### PR TITLE
fix: add text search fallback when embedding service unavailable

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore/QueryHandlers/IssueQueryHandlers/IssueTextSearchQueryHandler.cs
+++ b/src/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore/QueryHandlers/IssueQueryHandlers/IssueTextSearchQueryHandler.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+using Olbrasoft.GitHub.Issues.Data.Dtos;
+using Olbrasoft.GitHub.Issues.Data.Entities;
+using Olbrasoft.GitHub.Issues.Data.Queries.IssueQueries;
+
+namespace Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.QueryHandlers.IssueQueryHandlers;
+
+/// <summary>
+/// Handles text-based search queries using ILIKE pattern matching.
+/// Fallback when semantic/vector search is unavailable.
+/// </summary>
+public class IssueTextSearchQueryHandler : GitHubDbQueryHandler<Issue, IssueTextSearchQuery, IssueSearchPageDto>
+{
+    public IssueTextSearchQueryHandler(GitHubDbContext context) : base(context)
+    {
+    }
+
+    protected override async Task<IssueSearchPageDto> GetResultToHandleAsync(
+        IssueTextSearchQuery query, CancellationToken token)
+    {
+        if (string.IsNullOrWhiteSpace(query.SearchText))
+        {
+            return new IssueSearchPageDto();
+        }
+
+        var baseQuery = BuildBaseQuery(query.SearchText, query.State, query.RepositoryIds);
+
+        var totalCount = await baseQuery.CountAsync(token);
+        var skip = (query.Page - 1) * query.PageSize;
+
+        var results = await baseQuery
+            .OrderByDescending(i => i.Number)
+            .Skip(skip)
+            .Take(query.PageSize)
+            .Select(i => new IssueSearchResultDto
+            {
+                Id = i.Id,
+                IssueNumber = i.Number,
+                Title = i.Title,
+                IsOpen = i.IsOpen,
+                Url = i.Url,
+                RepositoryFullName = i.Repository.FullName,
+                Similarity = 0.5f, // Fixed similarity for text search (lower than semantic)
+                Labels = i.IssueLabels.Select(il => new LabelDto(il.Label.Name, il.Label.Color)).ToList()
+            })
+            .ToListAsync(token);
+
+        return new IssueSearchPageDto
+        {
+            Results = results,
+            TotalCount = totalCount,
+            Page = query.Page,
+            PageSize = query.PageSize,
+            TotalPages = (int)Math.Ceiling((double)totalCount / query.PageSize)
+        };
+    }
+
+    private IQueryable<Issue> BuildBaseQuery(string searchText, string state, IReadOnlyList<int>? repositoryIds)
+    {
+        var pattern = $"%{searchText}%";
+
+        // Search only in Title - issue body is fetched from GitHub on demand
+        var query = Entities
+            .Include(i => i.Repository)
+            .Include(i => i.IssueLabels)
+                .ThenInclude(il => il.Label)
+            .Where(i => EF.Functions.ILike(i.Title, pattern));
+
+        if (repositoryIds != null && repositoryIds.Count > 0)
+        {
+            query = query.Where(i => repositoryIds.Contains(i.RepositoryId));
+        }
+
+        if (string.Equals(state, "open", StringComparison.OrdinalIgnoreCase))
+        {
+            query = query.Where(i => i.IsOpen);
+        }
+        else if (string.Equals(state, "closed", StringComparison.OrdinalIgnoreCase))
+        {
+            query = query.Where(i => !i.IsOpen);
+        }
+
+        return query;
+    }
+}

--- a/src/Olbrasoft.GitHub.Issues.Data/Queries/IssueQueries/IssueTextSearchQuery.cs
+++ b/src/Olbrasoft.GitHub.Issues.Data/Queries/IssueQueries/IssueTextSearchQuery.cs
@@ -1,0 +1,35 @@
+using Olbrasoft.Data.Cqrs;
+using Olbrasoft.GitHub.Issues.Data.Dtos;
+using Olbrasoft.Mediation;
+
+namespace Olbrasoft.GitHub.Issues.Data.Queries.IssueQueries;
+
+/// <summary>
+/// Query for text-based search (LIKE pattern matching) as fallback when semantic search is unavailable.
+/// Searches in issue title and body text.
+/// </summary>
+public class IssueTextSearchQuery : BaseQuery<IssueSearchPageDto>
+{
+    /// <summary>Search text to match against title and body.</summary>
+    public string SearchText { get; set; } = string.Empty;
+
+    /// <summary>Filter by state: "open", "closed", or "all".</summary>
+    public string State { get; set; } = "all";
+
+    /// <summary>Current page number (1-based).</summary>
+    public int Page { get; set; } = 1;
+
+    /// <summary>Number of results per page.</summary>
+    public int PageSize { get; set; } = 10;
+
+    /// <summary>Optional list of repository IDs to filter results.</summary>
+    public IReadOnlyList<int>? RepositoryIds { get; set; }
+
+    public IssueTextSearchQuery(IQueryProcessor processor) : base(processor)
+    {
+    }
+
+    public IssueTextSearchQuery(IMediator mediator) : base(mediator)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IssueTextSearchQuery` for LIKE-based text search
- Add `IssueTextSearchQueryHandler` using PostgreSQL ILIKE pattern matching
- Update `IssueSearchService` to fall back to text search when embedding fails

## Root Cause
In Azure production, Ollama is not available (it's a local service). When embedding generation fails, the search returned no results silently.

## Solution
Added a fallback mechanism that uses ILIKE text search when semantic search (embeddings) is unavailable. This allows text search to work in any environment.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)