### PR TITLE
fix: send notification when title translation fails (#190)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Business/Services/TitleTranslationService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/Services/TitleTranslationService.cs
@@ -76,6 +76,12 @@ public class TitleTranslationService : ITitleTranslationService
         if (!result.Success || string.IsNullOrWhiteSpace(result.Translation))
         {
             _logger.LogWarning("[TitleTranslation] Translation failed for issue {Id}: {Error}", issueId, result.Error);
+
+            // Send notification with original title so the UI can stop showing spinner
+            await _notifier.NotifyTitleTranslatedAsync(
+                new TitleTranslationNotificationDto(issueId, issue.Title, targetLanguage, "failed"),
+                cancellationToken);
+
             return;
         }
 


### PR DESCRIPTION
## Summary
- Fixed issue where translations not returning would leave UI showing perpetual spinner
- When translation fails (e.g., DeepL API key not configured), now sends SignalR notification with original title and `provider: "failed"`
- UI can now detect failed translations and stop showing loading state

Fixes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)