### PR TITLE
fix: update system prompt to not prefix summaries (#189)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/appsettings.json
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/appsettings.json
@@ -33,7 +33,7 @@
       "Model": "llama-4-scout-17b-16e-instruct",
       "MaxTokens": 500,
       "Temperature": 0.3,
-      "SystemPrompt": "You are a helpful assistant that summarizes GitHub issues concisely. Provide a 2-3 sentence summary in English that captures the key points. Do NOT use <think> tags - respond directly with the summary.",
+      "SystemPrompt": "You are a helpful assistant that summarizes GitHub issues concisely. Provide a 2-3 sentence summary in English that captures the key points. Start directly with the summary content - do NOT prefix with 'Summary:', 'Summary', or any similar label. Do NOT use <think> tags.",
       "OpenAICompatible": {
         "BaseUrl": "https://api.cerebras.ai/v1",
         "MaxTokens": 500,

--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/SummarizationSettings.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions/SummarizationSettings.cs
@@ -22,7 +22,7 @@ public class SummarizationSettings
     public double Temperature { get; set; } = 0.3;
 
     /// <summary>System prompt for summarization.</summary>
-    public string SystemPrompt { get; set; } = "You are a helpful assistant that summarizes GitHub issues concisely. Provide a 2-3 sentence summary in English that captures the key points. Do NOT use <think> tags - respond directly with the summary.";
+    public string SystemPrompt { get; set; } = "You are a helpful assistant that summarizes GitHub issues concisely. Provide a 2-3 sentence summary in English that captures the key points. Start directly with the summary content - do NOT prefix with 'Summary:', 'Summary', or any similar label. Do NOT use <think> tags.";
 
     /// <summary>
     /// OpenAI-compatible API settings.


### PR DESCRIPTION
## Summary
- Updated the summarization system prompt to explicitly instruct LLMs not to start responses with 'Summary:', 'Summary', or any similar label prefix
- Updated both `appsettings.json` and `SummarizationSettings.cs` (default value) to stay in sync

## Changes
The prompt now includes:
> "Start directly with the summary content - do NOT prefix with 'Summary:', 'Summary', or any similar label."

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)