### PR TITLE
fix: improve SignalR connection stability (#192)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Index.cshtml
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Index.cshtml
@@ -103,6 +103,7 @@
     <div class="results-container">
         <div class="results-header">
             <h2>Výsledky vyhledávání</h2>
+            <span class="signalr-status disconnected" title="Připojování..."></span>
             @if (Model.SearchResult.TotalCount > 0)
             {
                 <span class="results-count">

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Program.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Program.cs
@@ -6,7 +6,13 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add core services
 builder.Services.AddRazorPages();
-builder.Services.AddSignalR();
+builder.Services.AddSignalR(options =>
+{
+    // Increase timeouts to prevent disconnection on Azure/proxy environments
+    options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+    options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
+    options.HandshakeTimeout = TimeSpan.FromSeconds(30);
+});
 
 // Add session support
 builder.Services.AddDistributedMemoryCache();

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/css/site.css
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/css/site.css
@@ -1017,3 +1017,33 @@ footer {
     gap: 4px;
     margin-top: 8px;
 }
+
+/* SignalR connection status indicator */
+.signalr-status {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-left: 8px;
+    vertical-align: middle;
+    transition: background-color 0.3s ease;
+}
+
+.signalr-status.connected {
+    background-color: #28a745;
+    box-shadow: 0 0 4px #28a745;
+}
+
+.signalr-status.disconnected {
+    background-color: #dc3545;
+    animation: pulse-disconnected 1.5s infinite;
+}
+
+@keyframes pulse-disconnected {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed SignalR connection disconnecting after ~45 seconds of inactivity
- Added visual connection status indicator

## Changes

### Server-side (`Program.cs`)
- Configured SignalR timeouts:
  - `KeepAliveInterval`: 15 seconds (server sends pings)
  - `ClientTimeoutInterval`: 60 seconds (increased from default 30s)
  - `HandshakeTimeout`: 30 seconds

### Client-side (`issue-updates.js`)
- Added keep-alive ping every 30 seconds to prevent Azure/proxy idle disconnection
- Added `updateConnectionStatus()` to track connection state
- Updated reconnection handlers to restart keep-alive on reconnect

### UI (`Index.cshtml`, `site.css`)
- Added visual connection status indicator (green dot = connected, pulsing red = disconnected)
- Shows tooltip on hover with connection state in Czech

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)