### PR TITLE
feat: move system prompts to markdown files (#191)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
@@ -5,6 +5,7 @@ using Olbrasoft.GitHub.Issues.Business.Services;
 using Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.Services;
 using Olbrasoft.GitHub.Issues.Sync.Services;
 using Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Hubs;
+using Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Services;
 using Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
 using Olbrasoft.GitHub.Issues.Text.Transformation.Ollama;
 using Olbrasoft.GitHub.Issues.Text.Transformation.Cohere;
@@ -103,6 +104,12 @@ public static class ServiceExtensions
             var syncSettings = sp.GetRequiredService<IOptions<SyncSettings>>();
             return new EmbeddingTextBuilder(syncSettings.Value.MaxEmbeddingTextLength);
         });
+
+        // Prompt loader for external markdown prompts
+        services.AddSingleton<IPromptLoader, PromptLoader>();
+
+        // Post-configure to load prompts from files (overrides appsettings if files exist)
+        services.AddSingleton<IPostConfigureOptions<SummarizationSettings>, SummarizationPromptsPostConfigure>();
 
         return services;
     }

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.csproj
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.csproj
@@ -29,4 +29,11 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Copy prompt files to output -->
+  <ItemGroup>
+    <Content Include="Prompts\**\*.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Prompts/summarization-system.md
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Prompts/summarization-system.md
@@ -1,0 +1,1 @@
+You are a helpful assistant that summarizes GitHub issues concisely. Provide a 2-3 sentence summary in English that captures the key points. Start directly with the summary content - do NOT prefix with 'Summary:', 'Summary', or any similar label. Do NOT use <think> tags.

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Prompts/summarization-user.md
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Prompts/summarization-user.md
@@ -1,0 +1,3 @@
+Summarize this GitHub issue:
+
+{{content}}

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Prompts/translation-system.md
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Prompts/translation-system.md
@@ -1,0 +1,1 @@
+Translate the following text to {{targetLanguage}}. Preserve the meaning and tone. Output only the translation, nothing else.

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Services/PromptLoader.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Services/PromptLoader.cs
@@ -1,0 +1,140 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Services;
+
+/// <summary>
+/// Loads LLM prompts from markdown files in the Prompts directory.
+/// Caches prompts and watches for file changes in development.
+/// </summary>
+public interface IPromptLoader
+{
+    /// <summary>
+    /// Gets a prompt by name (without extension).
+    /// </summary>
+    /// <param name="promptName">Name of the prompt file (e.g., "summarization-system")</param>
+    /// <returns>The prompt content, or null if not found</returns>
+    string? GetPrompt(string promptName);
+
+    /// <summary>
+    /// Gets a prompt and replaces placeholders with values.
+    /// </summary>
+    /// <param name="promptName">Name of the prompt file</param>
+    /// <param name="replacements">Dictionary of placeholder -> value replacements</param>
+    /// <returns>The prompt content with replacements applied</returns>
+    string? GetPrompt(string promptName, IDictionary<string, string> replacements);
+}
+
+public class PromptLoader : IPromptLoader
+{
+    private readonly IWebHostEnvironment _environment;
+    private readonly ILogger<PromptLoader> _logger;
+    private readonly Dictionary<string, string> _cache = new();
+    private readonly object _cacheLock = new();
+    private readonly string _promptsPath;
+
+    public PromptLoader(IWebHostEnvironment environment, ILogger<PromptLoader> logger)
+    {
+        _environment = environment;
+        _logger = logger;
+        _promptsPath = Path.Combine(_environment.ContentRootPath, "Prompts");
+
+        // In development, set up file watcher for hot reload
+        if (_environment.IsDevelopment())
+        {
+            SetupFileWatcher();
+        }
+    }
+
+    public string? GetPrompt(string promptName)
+    {
+        lock (_cacheLock)
+        {
+            // Check cache first (in production, always use cache)
+            if (_cache.TryGetValue(promptName, out var cached))
+            {
+                return cached;
+            }
+
+            // Load from file
+            var filePath = Path.Combine(_promptsPath, $"{promptName}.md");
+
+            if (!File.Exists(filePath))
+            {
+                _logger.LogWarning("Prompt file not found: {Path}", filePath);
+                return null;
+            }
+
+            try
+            {
+                var content = File.ReadAllText(filePath).Trim();
+                _cache[promptName] = content;
+                _logger.LogInformation("Loaded prompt from file: {PromptName}", promptName);
+                return content;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load prompt: {PromptName}", promptName);
+                return null;
+            }
+        }
+    }
+
+    public string? GetPrompt(string promptName, IDictionary<string, string> replacements)
+    {
+        var prompt = GetPrompt(promptName);
+        if (prompt == null)
+        {
+            return null;
+        }
+
+        foreach (var (key, value) in replacements)
+        {
+            prompt = prompt.Replace($"{{{{{key}}}}}", value);
+        }
+
+        return prompt;
+    }
+
+    private void SetupFileWatcher()
+    {
+        try
+        {
+            if (!Directory.Exists(_promptsPath))
+            {
+                return;
+            }
+
+            var watcher = new FileSystemWatcher(_promptsPath, "*.md")
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime,
+                EnableRaisingEvents = true
+            };
+
+            watcher.Changed += OnPromptFileChanged;
+            watcher.Created += OnPromptFileChanged;
+
+            _logger.LogInformation("Prompt file watcher enabled for development");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to set up prompt file watcher");
+        }
+    }
+
+    private void OnPromptFileChanged(object sender, FileSystemEventArgs e)
+    {
+        if (string.IsNullOrEmpty(e.Name))
+        {
+            return;
+        }
+
+        var promptName = Path.GetFileNameWithoutExtension(e.Name);
+
+        lock (_cacheLock)
+        {
+            _cache.Remove(promptName);
+        }
+
+        _logger.LogInformation("Prompt cache cleared for: {PromptName}", promptName);
+    }
+}

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Services/SummarizationPromptsPostConfigure.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Services/SummarizationPromptsPostConfigure.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Options;
+using Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions;
+
+namespace Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.Services;
+
+/// <summary>
+/// Post-configures SummarizationSettings by loading prompts from external markdown files.
+/// Prompts from files override the values from appsettings.json.
+/// </summary>
+public class SummarizationPromptsPostConfigure : IPostConfigureOptions<SummarizationSettings>
+{
+    private readonly IPromptLoader _promptLoader;
+    private readonly ILogger<SummarizationPromptsPostConfigure> _logger;
+
+    public SummarizationPromptsPostConfigure(
+        IPromptLoader promptLoader,
+        ILogger<SummarizationPromptsPostConfigure> logger)
+    {
+        _promptLoader = promptLoader;
+        _logger = logger;
+    }
+
+    public void PostConfigure(string? name, SummarizationSettings options)
+    {
+        var systemPrompt = _promptLoader.GetPrompt("summarization-system");
+        if (!string.IsNullOrEmpty(systemPrompt))
+        {
+            options.SystemPrompt = systemPrompt;
+            _logger.LogInformation("Loaded summarization system prompt from file");
+        }
+        else
+        {
+            _logger.LogDebug("Using default summarization system prompt from appsettings");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Added support for storing LLM prompts in external markdown files that can be edited without recompilation.

## Changes

### New files
- `Prompts/summarization-system.md` - System prompt for AI summarization
- `Prompts/summarization-user.md` - User prompt template with `{{content}}` placeholder
- `Prompts/translation-system.md` - System prompt for translations
- `Services/PromptLoader.cs` - Service to load and cache prompts from files
- `Services/SummarizationPromptsPostConfigure.cs` - Post-configure to override appsettings

### Features
- Prompts are cached in memory for performance
- File watcher enables hot-reload in development mode
- Fallback to appsettings.json if prompt files are missing
- Prompts are copied to output directory during build

## Benefits
- Edit prompts without code changes or recompilation
- Instant updates in development via file watcher
- Prompts versioned with the codebase
- Clear separation of concerns (prompts vs code)

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)