### PR TITLE
Move language selector to site header (site-wide setting)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Index.cshtml
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Index.cshtml
@@ -82,14 +82,9 @@
                     }
                 }
             </select>
-
-            <label for="languageSelect">Jazyk:</label>
-            <select name="Lang" id="languageSelect" class="language-select">
-                @if (Model.Language == "en") { <option value="en" selected>English</option> } else { <option value="en">English</option> }
-                @if (Model.Language == "de") { <option value="de" selected>Deutsch</option> } else { <option value="de">Deutsch</option> }
-                @if (Model.Language == "cs") { <option value="cs" selected>Čeština</option> } else { <option value="cs">Čeština</option> }
-            </select>
         </div>
+        <!-- Language is now in the site header (_Layout.cshtml) -->
+        <input type="hidden" name="Lang" value="@Model.Language" />
         <input type="hidden" name="PageNum" value="1" />
     </form>
 </div>
@@ -243,8 +238,8 @@
         window.initialSelectedRepos = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
             Model.SelectedRepositories.Select(r => new { id = r.Id, fullName = r.FullName })));
 
-        // Initialize language setting for SignalR client
-        window.selectedLanguage = '@Model.Language';
+        // Initialize language setting for SignalR client (use header language or server-side value)
+        window.selectedLanguage = window.siteLanguage || '@Model.Language';
 
         // Clear search function - clears session and reloads page
         function clearSearch() {

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Shared/_Layout.cshtml
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Pages/Shared/_Layout.cshtml
@@ -15,6 +15,16 @@
     <header>
         <nav>
             <a href="/" class="brand">GitHub Issues Search</a>
+            <div class="header-language-selector">
+                <label for="headerLanguageSelect">
+                    <span class="language-icon">🌐</span>
+                </label>
+                <select id="headerLanguageSelect" class="header-language-select" title="Select language">
+                    <option value="en">English</option>
+                    <option value="de">Deutsch</option>
+                    <option value="cs">Čeština</option>
+                </select>
+            </div>
         </nav>
     </header>
 
@@ -27,6 +37,7 @@
     </footer>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
+    <script src="~/js/header-language.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/css/site.css
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/css/site.css
@@ -19,6 +19,47 @@ header {
 header nav {
     max-width: 1200px;
     margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+/* Header language selector */
+.header-language-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.header-language-selector label {
+    display: flex;
+    align-items: center;
+}
+
+.language-icon {
+    font-size: 1.25rem;
+    cursor: pointer;
+}
+
+.header-language-select {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.9rem;
+    border: 1px solid #444d56;
+    border-radius: 6px;
+    background-color: #3a3f47;
+    color: white;
+    outline: none;
+    cursor: pointer;
+}
+
+.header-language-select:hover {
+    border-color: #586069;
+    background-color: #444d56;
+}
+
+.header-language-select:focus {
+    border-color: #0366d6;
+    box-shadow: 0 0 0 3px rgba(3, 102, 214, 0.3);
 }
 
 header .brand {

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/js/detail-updates.js
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/js/detail-updates.js
@@ -25,7 +25,8 @@
         issueId = parseInt(container.dataset.issueId, 10);
         const summaryPending = container.dataset.summaryPending === 'true';
         summaryLanguage = container.dataset.summaryLanguage || 'both';
-        selectedLanguage = container.dataset.selectedLanguage || 'cs';
+        // Use header language selector if available, otherwise fall back to data attribute
+        selectedLanguage = window.siteLanguage || container.dataset.selectedLanguage || 'cs';
 
         console.log('[detail-updates] Issue ID:', issueId, 'Summary pending:', summaryPending, 'Selected language:', selectedLanguage);
 

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/js/header-language.js
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/wwwroot/js/header-language.js
@@ -1,0 +1,67 @@
+// Site-wide language selector for GitHub Issues Search
+(function () {
+    'use strict';
+
+    const STORAGE_KEY = 'github-issues-language';
+    const DEFAULT_LANGUAGE = 'cs';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        initializeLanguageSelector();
+    });
+
+    function initializeLanguageSelector() {
+        const selector = document.getElementById('headerLanguageSelect');
+        if (!selector) return;
+
+        // Get current language (priority: URL > localStorage > default)
+        const currentLanguage = getCurrentLanguage();
+        selector.value = currentLanguage;
+
+        // Handle language change
+        selector.addEventListener('change', function () {
+            const newLanguage = this.value;
+            setLanguage(newLanguage);
+            redirectWithLanguage(newLanguage);
+        });
+
+        // Expose language for other scripts
+        window.siteLanguage = currentLanguage;
+    }
+
+    function getCurrentLanguage() {
+        // 1. Check URL parameter
+        const urlParams = new URLSearchParams(window.location.search);
+        const urlLang = urlParams.get('Lang');
+        if (isValidLanguage(urlLang)) {
+            // Also save to localStorage for persistence
+            localStorage.setItem(STORAGE_KEY, urlLang);
+            return urlLang;
+        }
+
+        // 2. Check localStorage
+        const storedLang = localStorage.getItem(STORAGE_KEY);
+        if (isValidLanguage(storedLang)) {
+            return storedLang;
+        }
+
+        // 3. Default
+        return DEFAULT_LANGUAGE;
+    }
+
+    function setLanguage(language) {
+        if (isValidLanguage(language)) {
+            localStorage.setItem(STORAGE_KEY, language);
+            window.siteLanguage = language;
+        }
+    }
+
+    function redirectWithLanguage(language) {
+        const url = new URL(window.location.href);
+        url.searchParams.set('Lang', language);
+        window.location.href = url.toString();
+    }
+
+    function isValidLanguage(lang) {
+        return lang === 'en' || lang === 'de' || lang === 'cs';
+    }
+})();


### PR DESCRIPTION
## Summary
- Move language selector from search form to site header navigation
- Language setting now persists across all pages (localStorage + URL parameter)
- Create `header-language.js` for cross-page language state management
- Style header dropdown with dark theme matching the header

## Changes
- `_Layout.cshtml`: Add language selector with globe icon in header nav
- `header-language.js`: New script for language selection and persistence
- `Index.cshtml`: Remove language dropdown from filter row, keep hidden input
- `site.css`: Add header language selector styles
- `detail-updates.js`: Use `window.siteLanguage` for language preference

## Test plan
- [x] Build passes
- [x] All 121 tests pass
- [ ] Language selector visible in header on all pages
- [ ] Changing language redirects with `?Lang=xx` parameter
- [ ] Language persists when navigating between pages
- [ ] Search results respect header language setting
- [ ] Detail page respects header language setting

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)