### PR TITLE
Fix PromptLoader path resolution for Azure deployment

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Services/PromptLoader.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Services/PromptLoader.cs
@@ -36,7 +36,20 @@ public class PromptLoader : IPromptLoader
     {
         _environment = environment;
         _logger = logger;
-        _promptsPath = Path.Combine(_environment.ContentRootPath, "Prompts");
+
+        // Try multiple paths for Azure compatibility
+        var possiblePaths = new[]
+        {
+            Path.Combine(_environment.ContentRootPath, "Prompts"),
+            Path.Combine(AppContext.BaseDirectory, "Prompts"),
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Prompts")
+        };
+
+        _promptsPath = possiblePaths.FirstOrDefault(Directory.Exists)
+            ?? possiblePaths[0]; // Fallback to first option
+
+        _logger.LogInformation("PromptLoader using path: {Path} (exists: {Exists})",
+            _promptsPath, Directory.Exists(_promptsPath));
 
         // In development, set up file watcher for hot reload
         if (_environment.IsDevelopment())


### PR DESCRIPTION
## Summary
Fix potential 500 error on Azure App Service by trying multiple paths for the Prompts directory.

## Problem
On Azure, `ContentRootPath` may not always point to where published files are located. The PromptLoader was hardcoded to use `ContentRootPath`, which could fail to find the Prompts folder.

## Solution
- Try multiple possible paths: ContentRootPath, AppContext.BaseDirectory, AppDomain.CurrentDomain.BaseDirectory
- Use the first path where the directory exists
- Add logging to show which path is actually used

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Deploy to Azure and verify search works

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)