### PR TITLE
Fix: Graceful handling when Ollama is not configured

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Text.Transformation.Ollama/OllamaEmbeddingService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Text.Transformation.Ollama/OllamaEmbeddingService.cs
@@ -31,7 +31,17 @@ public class OllamaEmbeddingService : IEmbeddingService, IServiceLifecycleManage
         _settings = settings.Value;
         _logger = logger;
 
-        _httpClient.BaseAddress = new Uri(_settings.BaseUrl);
+        // Set shorter timeout for quick failure detection (5 seconds instead of default 100)
+        _httpClient.Timeout = TimeSpan.FromSeconds(5);
+
+        if (!string.IsNullOrEmpty(_settings.BaseUrl))
+        {
+            _httpClient.BaseAddress = new Uri(_settings.BaseUrl);
+        }
+        else
+        {
+            _logger.LogWarning("Ollama BaseUrl is not configured, embedding service will be unavailable");
+        }
     }
 
     public bool IsConfigured => !string.IsNullOrEmpty(_settings.BaseUrl);

--- a/test/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.Tests/Services/OllamaEmbeddingServiceTests.cs
+++ b/test/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.Tests/Services/OllamaEmbeddingServiceTests.cs
@@ -60,14 +60,32 @@ public class OllamaEmbeddingServiceTests
     }
 
     [Fact]
-    public void Constructor_WhenBaseUrlEmpty_ThrowsUriFormatException()
+    public void Constructor_WhenBaseUrlEmpty_DoesNotThrow()
     {
         // Arrange
         _settings.BaseUrl = "";
         var handler = CreateMockHandler(new HttpResponseMessage(HttpStatusCode.OK));
 
-        // Act & Assert
-        Assert.Throws<UriFormatException>(() => CreateService(handler.Object));
+        // Act - should not throw (graceful handling for Azure deployment)
+        var service = CreateService(handler.Object);
+
+        // Assert - service should be created but not configured
+        Assert.False(service.IsConfigured);
+    }
+
+    [Fact]
+    public void IsConfigured_WhenBaseUrlEmpty_ReturnsFalse()
+    {
+        // Arrange
+        _settings.BaseUrl = "";
+        var handler = CreateMockHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var service = CreateService(handler.Object);
+
+        // Act
+        var result = service.IsConfigured;
+
+        // Assert
+        Assert.False(result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add 5 second HTTP timeout for quick failure detection (was 100s default)
- Handle empty BaseUrl gracefully instead of throwing UriFormatException
- Log warning when Ollama is not configured
- Update tests to reflect new graceful handling behavior

This prevents long timeouts on Azure where Ollama localhost is unavailable. The search will now fail fast and fallback to text search instead of hanging for 100 seconds.

## Test plan
- [x] Tests updated and passing (27 tests in OllamaEmbeddingServiceTests)
- [ ] Deploy to Azure and verify search works
- [ ] Verify text search fallback functions correctly

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)