### PR TITLE
Add Cohere as fallback translator when DeepL fails

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
@@ -78,6 +78,10 @@ public static class ServiceExtensions
         services.AddHttpClient<ITranslator, DeepLTranslator>()
             .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(30));
 
+        // Fallback translation service (Cohere AI) - used when DeepL fails or is not configured
+        services.AddHttpClient<ITranslationService, CohereTranslationService>()
+            .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(60));
+
         // Business services
         services.AddScoped<IIssueSearchService, IssueSearchService>();
         services.AddScoped<IIssueDetailService, IssueDetailService>();


### PR DESCRIPTION
## Summary
- Added Cohere AI as fallback translator when DeepL API key is not configured
- Modified `TitleTranslationService` to accept optional `ITranslationService` for fallback
- Registered `CohereTranslationService` as `ITranslationService` in DI container
- When primary (DeepL) translation fails, the service now tries Cohere as fallback
- Fallback currently supports Czech language only

## Root Cause
DeepL API key is not configured in production (appsettings.Production.json), causing all title translations to fail silently. The Cohere API key IS configured.

## Changes
- `TitleTranslationService.cs`: Added fallback translator logic
- `ServiceExtensions.cs`: Registered `CohereTranslationService` as `ITranslationService`

## Test plan
- [ ] All unit tests pass
- [ ] Deploy to production
- [ ] Test Czech translation on search results page
- [ ] Verify translations appear via Cohere when DeepL fails

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)