### PR TITLE
Fix fallback handling for 'both' language mode (#209)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Business/Services/IssueDetailService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/Services/IssueDetailService.cs
@@ -243,11 +243,20 @@ public class IssueDetailService : IIssueDetailService
             // All translation attempts failed - use English summary as fallback
             _logger.LogWarning("[GenerateSummary] All translation attempts failed for issue {Id}: {Error}. Using English summary.", issueId, translateResult.Error);
 
-            // If we haven't sent English yet (cs-only mode), send it now as fallback
+            // Send English as fallback for Czech language modes
+            // For "cs": We haven't sent English yet, send it now
+            // For "both": We sent English already but client hid it (waiting for Czech), send with "cs" language so it shows
             if (language == "cs")
             {
                 await _summaryNotifier.NotifySummaryReadyAsync(
                     new SummaryNotificationDto(issueId, summarizeResult.Summary, enProvider + " (EN fallback)", "en"),
+                    cancellationToken);
+            }
+            else if (language == "both")
+            {
+                // Send English text but with "cs" language marker so client shows it in Czech div
+                await _summaryNotifier.NotifySummaryReadyAsync(
+                    new SummaryNotificationDto(issueId, summarizeResult.Summary, enProvider + " (překlad nedostupný)", "cs"),
                     cancellationToken);
             }
 
@@ -340,11 +349,20 @@ public class IssueDetailService : IIssueDetailService
             // All translation attempts failed - use English summary as fallback
             _logger.LogWarning("[GenerateSummaryFromBody] All translation attempts failed for issue {Id}: {Error}. Using English summary.", issueId, translateResult.Error);
 
-            // If we haven't sent English yet (cs-only mode), send it now as fallback
+            // Send English as fallback for Czech language modes
+            // For "cs": We haven't sent English yet, send it now
+            // For "both": We sent English already but client hid it (waiting for Czech), send with "cs" language so it shows
             if (language == "cs")
             {
                 await _summaryNotifier.NotifySummaryReadyAsync(
                     new SummaryNotificationDto(issueId, summarizeResult.Summary, enProvider + " (EN fallback)", "en"),
+                    cancellationToken);
+            }
+            else if (language == "both")
+            {
+                // Send English text but with "cs" language marker so client shows it in Czech div
+                await _summaryNotifier.NotifySummaryReadyAsync(
+                    new SummaryNotificationDto(issueId, summarizeResult.Summary, enProvider + " (překlad nedostupný)", "cs"),
                     cancellationToken);
             }
 


### PR DESCRIPTION
## Summary
Fixes the issue where users see raw body preview instead of AI summary when translation fails.

### Problem
When `language == "both"`:
1. English summary is sent (and hidden by JS because `selectedLanguage === 'cs'`)
2. Translation fails (DeepL + Cohere both fail)
3. No fallback is sent → user sees body preview instead of AI summary

### Solution
When translation fails in "both" mode:
1. English summary is still sent first
2. English text is sent again with `language: "cs"` marker
3. Client displays it in the Czech summary div
4. Provider shows "(překlad nedostupný)" to indicate translation unavailable

### Test Added
- `WhenBothModeAndTranslationFails_SendsEnglishAsCzechFallback`

## Related Issue
Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)