### PR TITLE
Switch from DeepL to Azure Translator as primary translation service (#209)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.csproj
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Olbrasoft.GitHub.Issues.Text.Transformation.Cohere\Olbrasoft.GitHub.Issues.Text.Transformation.Cohere.csproj" />
     <ProjectReference Include="..\Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible\Olbrasoft.GitHub.Issues.Text.Transformation.OpenAICompatible.csproj" />
     <ProjectReference Include="..\Olbrasoft.Text.Translation.Abstractions\Olbrasoft.Text.Translation.Abstractions.csproj" />
+    <ProjectReference Include="..\Olbrasoft.Text.Translation.Azure\Olbrasoft.Text.Translation.Azure.csproj" />
     <ProjectReference Include="..\Olbrasoft.Text.Translation.DeepL\Olbrasoft.Text.Translation.DeepL.csproj" />
   </ItemGroup>
 

--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/appsettings.json
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/appsettings.json
@@ -80,6 +80,11 @@
   "GitHubApp": {
     "WebhookSecret": ""
   },
+  "AzureTranslator": {
+    "ApiKey": "",
+    "Region": "westeurope",
+    "Endpoint": "https://api.cognitive.microsofttranslator.com/"
+  },
   "DeepL": {
     "Endpoint": "https://api-free.deepl.com/v2/",
     "ApiKey": ""

--- a/src/Olbrasoft.GitHub.Issues.Business/Olbrasoft.GitHub.Issues.Business.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Business/Olbrasoft.GitHub.Issues.Business.csproj
@@ -5,6 +5,7 @@
     <ProjectReference Include="..\Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore\Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions\Olbrasoft.GitHub.Issues.Text.Transformation.Abstractions.csproj" />
     <ProjectReference Include="..\Olbrasoft.Text.Translation.Abstractions\Olbrasoft.Text.Translation.Abstractions.csproj" />
+    <ProjectReference Include="..\Olbrasoft.Text.Translation.DeepL\Olbrasoft.Text.Translation.DeepL.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Switch primary translator from DeepL to Azure Translator (Cognitive Services)
- Keep DeepL as fallback translator (instead of Cohere)
- Remove Cohere/LLM-based translation from the translation chain
- Add `AzureTranslator` configuration section to appsettings.json

## Why
Per user requirement: translations must use proper translation services (DeepL, Azure Translator), NOT LLM-based services like Cohere.

## Configuration Required
After merging, the following Azure App Configuration settings need to be added:
- `AzureTranslator:ApiKey` - Azure Translator API key
- `AzureTranslator:Region` - Azure region (default: westeurope)

## Test plan
- [x] All 223 tests pass
- [ ] Deploy to Azure and configure API keys
- [ ] Verify titles are translated via Azure Translator (not Cohere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)