### PR TITLE
Add AiProviders configuration section for summarization (#215)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/appsettings.json
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/appsettings.json
@@ -88,5 +88,22 @@
   "DeepL": {
     "Endpoint": "https://api-free.deepl.com/v2/",
     "ApiKey": ""
+  },
+  "AiProviders": {
+    "Cerebras": {
+      "Endpoint": "https://api.cerebras.ai/v1/",
+      "Models": ["llama-4-scout-17b-16e-instruct", "llama3.1-8b"],
+      "Keys": []
+    },
+    "Groq": {
+      "Endpoint": "https://api.groq.com/openai/v1/",
+      "Models": ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"],
+      "Keys": []
+    },
+    "Cohere": {
+      "Endpoint": "https://api.cohere.com/v2/",
+      "TranslationModels": ["command-a-03-2025"],
+      "Keys": []
+    }
   }
 }


### PR DESCRIPTION
## Summary
Adds the missing `AiProviders` configuration section to appsettings.json.

The `OpenAICompatibleSummarizationService` builds provider/key/model combinations from this section. Without it, summarization fails with "No AI providers configured".

## Configuration Added
```json
"AiProviders": {
  "Cerebras": {
    "Endpoint": "https://api.cerebras.ai/v1/",
    "Models": ["llama-4-scout-17b-16e-instruct", "llama3.1-8b"]
  },
  "Groq": {
    "Endpoint": "https://api.groq.com/openai/v1/",
    "Models": ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"]
  }
}
```

## Note
API keys are already configured in Azure App Configuration:
- `AiProviders:Cerebras:Keys:0`
- `AiProviders:Groq:Keys:0`

## Test plan
- [x] Build passes
- [x] All 223 tests pass
- [ ] Deploy and verify SummaryReceived events in browser console

Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)