### PR TITLE
Fix sync to not skip issues when embedding generation fails

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Data/Dtos/SyncStatisticsDto.cs
+++ b/src/Olbrasoft.GitHub.Issues.Data/Dtos/SyncStatisticsDto.cs
@@ -31,6 +31,11 @@ public class SyncStatisticsDto
     public int Unchanged { get; set; }
 
     /// <summary>
+    /// Number of issues where embedding generation failed (still synced without embedding).
+    /// </summary>
+    public int EmbeddingsFailed { get; set; }
+
+    /// <summary>
     /// The timestamp used for incremental sync (null if full sync).
     /// </summary>
     public DateTimeOffset? SinceTimestamp { get; set; }
@@ -45,5 +50,6 @@ public class SyncStatisticsDto
         Created += other.Created;
         Updated += other.Updated;
         Unchanged += other.Unchanged;
+        EmbeddingsFailed += other.EmbeddingsFailed;
     }
 }

--- a/src/Olbrasoft.GitHub.Issues.Sync/Services/IssueSyncService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Sync/Services/IssueSyncService.cs
@@ -82,9 +82,9 @@ public class IssueSyncService : IIssueSyncService
             if (embedding == null)
             {
                 _logger.LogWarning(
-                    "SKIPPED issue #{Number} ({Title}): Could not generate embedding.",
+                    "Issue #{Number} ({Title}): Could not generate embedding - syncing without embedding.",
                     ghIssue.Number, ghIssue.Title);
-                continue;
+                stats.EmbeddingsFailed++;
             }
 
             // Save issue


### PR DESCRIPTION
## Summary

- **Root cause**: `IssueSyncService` skipped issues entirely when embedding generation failed (`continue` statement on line 87)
- **Impact**: New issues like #206 were never saved to the database when Ollama/Cohere was unavailable

## Changes

- **IssueSyncService.cs**: Remove `continue` statement - issues now save with null embedding
- **SyncStatisticsDto.cs**: Added `EmbeddingsFailed` counter for monitoring

## Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Embedding succeeds | ✅ Issue saved | ✅ Issue saved |
| Embedding fails | ❌ Issue skipped | ✅ Issue saved (null embedding) |

Issues with null embeddings:
- ✅ Appear in basic search (title/keyword)
- ❌ Not included in semantic/vector search

## Test Plan

- [x] Build passes
- [x] All 143 tests pass
- [ ] Deploy and verify #206 appears after sync

Fixes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)