### PR TITLE
Refactor: Extract cache freshness validation (DRY - issue #312)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore/Repositories/EfCoreRepositoryBase.cs
+++ b/src/Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore/Repositories/EfCoreRepositoryBase.cs
@@ -1,0 +1,119 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Olbrasoft.GitHub.Issues.Data.Entities;
+
+namespace Olbrasoft.GitHub.Issues.Data.EntityFrameworkCore.Repositories;
+
+/// <summary>
+/// Base class for EF Core repositories with shared cache functionality.
+/// Provides common methods for duplicate key detection, cache validation, and logging.
+/// </summary>
+public abstract class EfCoreRepositoryBase
+{
+    protected readonly GitHubDbContext Context;
+    protected readonly ILogger Logger;
+
+    protected EfCoreRepositoryBase(GitHubDbContext context, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        Context = context;
+        Logger = logger;
+    }
+
+    /// <summary>
+    /// Gets cached text by issue ID, language ID, and text type ID.
+    /// </summary>
+    protected async Task<CachedText?> GetCachedTextInternalAsync(
+        int issueId,
+        int languageId,
+        int textTypeId,
+        CancellationToken cancellationToken = default)
+    {
+        return await Context.CachedTexts
+            .FirstOrDefaultAsync(t =>
+                t.IssueId == issueId &&
+                t.LanguageId == languageId &&
+                t.TextTypeId == textTypeId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Deletes cached text from the database.
+    /// </summary>
+    protected async Task DeleteCachedTextInternalAsync(CachedText cachedText, CancellationToken cancellationToken = default)
+    {
+        Context.CachedTexts.Remove(cachedText);
+        await Context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets cached text if it's still fresh (issue hasn't been updated after cache was created).
+    /// Automatically deletes stale cache with logging.
+    /// </summary>
+    protected async Task<string?> GetIfFreshInternalAsync(
+        int issueId,
+        int languageId,
+        int textTypeId,
+        DateTime issueUpdatedAt,
+        CancellationToken cancellationToken = default)
+    {
+        var cached = await GetCachedTextInternalAsync(issueId, languageId, textTypeId, cancellationToken);
+
+        if (cached == null) return null;
+
+        // Validate freshness - if issue was updated after cache, invalidate
+        if (issueUpdatedAt > cached.CachedAt)
+        {
+            // Cache is stale - delete it with logging
+            Logger.LogDebug(
+                "[Cache] Cache STALE for issue {IssueId}, language {LanguageId}, textType {TextTypeId} - issue updated {IssueUpdated}, cache created {CacheCreated}, deleting",
+                issueId,
+                languageId,
+                textTypeId,
+                issueUpdatedAt,
+                cached.CachedAt);
+
+            await DeleteCachedTextInternalAsync(cached, cancellationToken);
+            return null;
+        }
+
+        // Cache is fresh
+        return cached.Content;
+    }
+
+    /// <summary>
+    /// Saves cached text with duplicate key exception handling and logging.
+    /// </summary>
+    protected async Task SaveCachedTextInternalAsync(CachedText cachedText, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            Context.CachedTexts.Add(cachedText);
+            await Context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsDuplicateKeyException(ex))
+        {
+            // Concurrent insert - another request already cached this text
+            Logger.LogDebug(
+                "[Cache] Concurrent cache insert detected for Issue {IssueId}, Language {LanguageId}, TextType {TextTypeId}",
+                cachedText.IssueId,
+                cachedText.LanguageId,
+                cachedText.TextTypeId);
+        }
+    }
+
+    /// <summary>
+    /// Checks if exception is a duplicate key violation.
+    /// Supports PostgreSQL (23505), SQL Server (2627, 2601).
+    /// </summary>
+    protected static bool IsDuplicateKeyException(DbUpdateException ex)
+    {
+        var message = ex.InnerException?.Message ?? string.Empty;
+        return message.Contains("23505") || // PostgreSQL unique violation
+               message.Contains("2627") ||  // SQL Server unique constraint
+               message.Contains("2601") ||  // SQL Server unique index
+               message.Contains("duplicate key") ||
+               message.Contains("unique constraint");
+    }
+}

--- a/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/CacheIntegrationTests.cs
+++ b/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/CacheIntegrationTests.cs
@@ -69,7 +69,7 @@ public class CacheIntegrationTests
             });
 
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             _mockTranslator.Object,
             _mockNotifier.Object,
             _fakeTimeProvider,
@@ -142,7 +142,7 @@ public class CacheIntegrationTests
             });
 
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             _mockTranslator.Object,
             _mockNotifier.Object,
             _fakeTimeProvider,
@@ -208,7 +208,7 @@ public class CacheIntegrationTests
             .ReturnsAsync(new TranslatorResult { Success = true, Translation = "Neue Funktion", Provider = "Azure" });
 
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             _mockTranslator.Object,
             _mockNotifier.Object,
             _fakeTimeProvider,
@@ -261,7 +261,7 @@ public class CacheIntegrationTests
         );
         await context.SaveChangesAsync();
 
-        var repository = new EfCoreCachedTextRepository(context);
+        var repository = new EfCoreCachedTextRepository(context, new Mock<ILogger<EfCoreCachedTextRepository>>().Object);
         var mockLogger = new Mock<ILogger<TranslationCacheService>>();
         var cacheService = new TranslationCacheService(repository, mockLogger.Object);
 
@@ -301,7 +301,7 @@ public class CacheIntegrationTests
         );
         await context.SaveChangesAsync();
 
-        var repository = new EfCoreCachedTextRepository(context);
+        var repository = new EfCoreCachedTextRepository(context, new Mock<ILogger<EfCoreCachedTextRepository>>().Object);
         var mockLogger = new Mock<ILogger<TranslationCacheService>>();
         var cacheService = new TranslationCacheService(repository, mockLogger.Object);
 

--- a/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/CacheTimeProviderTests.cs
+++ b/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/CacheTimeProviderTests.cs
@@ -58,7 +58,7 @@ public class CacheTimeProviderTests
             });
 
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             _mockTranslator.Object,
             _mockNotifier.Object,
             _fakeTimeProvider,
@@ -114,7 +114,7 @@ public class CacheTimeProviderTests
         await context.SaveChangesAsync();
 
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             _mockTranslator.Object,
             _mockNotifier.Object,
             _fakeTimeProvider,
@@ -186,7 +186,7 @@ public class CacheTimeProviderTests
             });
 
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             _mockTranslator.Object,
             _mockNotifier.Object,
             _fakeTimeProvider,
@@ -235,7 +235,7 @@ public class CacheTimeProviderTests
         await context.SaveChangesAsync();
 
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             _mockTranslator.Object,
             _mockNotifier.Object,
             _fakeTimeProvider,
@@ -300,7 +300,7 @@ public class CacheTimeProviderTests
         _fakeTimeProvider.Advance(TimeSpan.FromDays(30));
 
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             _mockTranslator.Object,
             _mockNotifier.Object,
             _fakeTimeProvider,

--- a/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/TitleTranslationFallbackIntegrationTests.cs
+++ b/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/TitleTranslationFallbackIntegrationTests.cs
@@ -69,7 +69,7 @@ public class TitleTranslationFallbackIntegrationTests
 
         // Arrange - Create service with failing primary and real DeepL fallback
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             mockPrimaryTranslator.Object,
             _mockNotifier.Object,
             TimeProvider.System,
@@ -128,7 +128,7 @@ public class TitleTranslationFallbackIntegrationTests
 
         // Arrange - Create service with failing primary and mocked fallback
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             mockPrimaryTranslator.Object,
             _mockNotifier.Object,
             TimeProvider.System,
@@ -186,7 +186,7 @@ public class TitleTranslationFallbackIntegrationTests
 
         // Arrange - Create service with both failing
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             mockPrimaryTranslator.Object,
             _mockNotifier.Object,
             TimeProvider.System,
@@ -238,7 +238,7 @@ public class TitleTranslationFallbackIntegrationTests
 
         // Arrange - Create service WITHOUT fallback (null)
         var service = new TitleTranslationService(
-            new EfCoreTranslationRepository(context),
+            new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object),
             mockPrimaryTranslator.Object,
             _mockNotifier.Object,
             TimeProvider.System,

--- a/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/TitleTranslationServiceTests.cs
+++ b/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/TitleTranslationServiceTests.cs
@@ -16,7 +16,7 @@ public class TitleTranslationServiceTests
 
     private TitleTranslationService CreateService(GitHubDbContext context, ITranslator? fallback = null)
     {
-        var repository = new EfCoreTranslationRepository(context);
+        var repository = new EfCoreTranslationRepository(context, new Mock<ILogger<EfCoreTranslationRepository>>().Object);
         return new TitleTranslationService(
             repository,
             _mockTranslator.Object,


### PR DESCRIPTION
## Summary

Removed **duplicate code** from cache-related services by extracting cache freshness validation logic into repository layer.

## Problem Solved

**Duplicate code violations (DRY):**
1. ❌ `IsDuplicateKeyException` duplicated in `TitleTranslationService` and `EfCoreCachedTextRepository`
2. ❌ Cache freshness validation duplicated in `IssueSummaryService` and `TitleTranslationService`
3. ❌ Exception handling missing in `EfCoreTranslationRepository`

## Changes

### 1. Removed Duplicate Code

**TitleTranslationService:**
- ❌ Removed `IsDuplicateKeyException()` method (already in repository)
- ❌ Removed `using Microsoft.EntityFrameworkCore;` (no longer needed)
- ✅ Simplified `SaveToCacheAsync()` - delegates to repository

**IssueSummaryService:**
- ❌ Removed `GetCachedSummaryAsync()` private method
- ✅ Now uses `_cachedTextRepository.GetIfFreshAsync()` directly

### 2. Added Repository Method

**New method signature:**
```csharp
Task<string?> GetIfFreshAsync(
    int issueId,
    int languageId,
    int textTypeId,
    DateTime issueUpdatedAt,
    CancellationToken cancellationToken = default);
```

**Added to interfaces:**
- `ICachedTextRepository`
- `ITranslationRepository`

**Implemented in:**
- `EfCoreCachedTextRepository`
- `EfCoreTranslationRepository`

**Logic encapsulated:**
- Get cached text by key
- Validate freshness (issueUpdatedAt <= cachedAt)
- Auto-delete stale cache
- Return content if fresh, null otherwise

### 3. Added Missing Exception Handling

**EfCoreTranslationRepository.SaveCachedTextAsync:**
```csharp
try
{
    _context.CachedTexts.Add(cachedText);
    await _context.SaveChangesAsync(cancellationToken);
}
catch (DbUpdateException ex) when (IsDuplicateKeyException(ex))
{
    // Handle concurrent inserts gracefully
}
```

## Code Reduction

| File | Before | After | Change |
|------|--------|-------|--------|
| TitleTranslationService | 265 lines | 215 lines | **-50 lines** |
| IssueSummaryService | 227 lines | 207 lines | **-20 lines** |
| **Total** | - | - | **-70 lines** |

## Benefits

✅ **DRY compliance** - Cache freshness validation in ONE place  
✅ **Single Responsibility** - Repository handles all cache logic  
✅ **Simplified services** - Focus on business logic, not infrastructure  
✅ **Better testability** - Repository method can be tested independently  
✅ **Consistency** - Both repositories have same exception handling  

## Testing

- ✅ Build successful
- ✅ All 412 tests passing (0 failures, 9 skipped)
- ✅ No breaking changes - services still work the same way

## Related Issues

Closes #312 (part of EPIC #321 - SRP Refactoring Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)