### PR TITLE
Create ISummaryCacheService for cache operations (issue #317)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
+++ b/src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Extensions/ServiceExtensions.cs
@@ -56,7 +56,8 @@ public static class ServiceExtensions
         services.AddScoped<IIssueSummaryOrchestrator, IssueSummaryOrchestrator>();
         services.AddScoped<IIssueDetailService, IssueDetailService>(); // Keep for backward compatibility
 
-        // Issue summary service (summarization + translation + notification)
+        // Issue summary services (issue #317 - SRP refactoring)
+        services.AddScoped<ISummaryCacheService, SummaryCacheService>();
         services.AddScoped<IIssueSummaryService, IssueSummaryService>();
 
         // SignalR notifiers

--- a/src/Olbrasoft.GitHub.Issues.Business/Summarization/ISummaryCacheService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/Summarization/ISummaryCacheService.cs
@@ -1,0 +1,36 @@
+namespace Olbrasoft.GitHub.Issues.Business.Summarization;
+
+/// <summary>
+/// Service for caching AI-generated summaries.
+/// Single responsibility: Summary cache operations only (SRP).
+/// </summary>
+public interface ISummaryCacheService
+{
+    /// <summary>
+    /// Gets cached summary if it exists and is fresh (not stale).
+    /// Returns null if cache doesn't exist or is stale.
+    /// </summary>
+    /// <param name="issueId">Database issue ID</param>
+    /// <param name="languageCode">Language code (EnUS or CsCZ)</param>
+    /// <param name="issueUpdatedAt">Issue's last update timestamp for freshness validation</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Cached summary or null</returns>
+    Task<string?> GetIfFreshAsync(
+        int issueId,
+        int languageCode,
+        DateTime issueUpdatedAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves summary to cache.
+    /// </summary>
+    /// <param name="issueId">Database issue ID</param>
+    /// <param name="languageCode">Language code (EnUS or CsCZ)</param>
+    /// <param name="summary">Summary text to cache</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task SaveAsync(
+        int issueId,
+        int languageCode,
+        string summary,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Olbrasoft.GitHub.Issues.Business/Summarization/SummaryCacheService.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/Summarization/SummaryCacheService.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging;
+using Olbrasoft.GitHub.Issues.Data;
+using Olbrasoft.GitHub.Issues.Data.Entities;
+using Olbrasoft.GitHub.Issues.Data.Repositories;
+
+namespace Olbrasoft.GitHub.Issues.Business.Summarization;
+
+/// <summary>
+/// Implementation of summary cache service.
+/// Handles caching of AI-generated summaries with freshness validation.
+/// </summary>
+public class SummaryCacheService : ISummaryCacheService
+{
+    private readonly ICachedTextRepository _repository;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<SummaryCacheService> _logger;
+
+    public SummaryCacheService(
+        ICachedTextRepository repository,
+        TimeProvider timeProvider,
+        ILogger<SummaryCacheService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _repository = repository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public async Task<string?> GetIfFreshAsync(
+        int issueId,
+        int languageCode,
+        DateTime issueUpdatedAt,
+        CancellationToken cancellationToken = default)
+    {
+        var textTypeId = (int)TextTypeCode.ListSummary;
+
+        var cachedSummary = await _repository.GetIfFreshAsync(
+            issueId,
+            languageCode,
+            textTypeId,
+            issueUpdatedAt,
+            cancellationToken);
+
+        if (cachedSummary != null)
+        {
+            _logger.LogDebug(
+                "[SummaryCacheService] Cache HIT for issue {IssueId}, language {LanguageCode}",
+                issueId,
+                languageCode);
+        }
+        else
+        {
+            _logger.LogDebug(
+                "[SummaryCacheService] Cache MISS for issue {IssueId}, language {LanguageCode}",
+                issueId,
+                languageCode);
+        }
+
+        return cachedSummary;
+    }
+
+    public async Task SaveAsync(
+        int issueId,
+        int languageCode,
+        string summary,
+        CancellationToken cancellationToken = default)
+    {
+        var textTypeId = (int)TextTypeCode.ListSummary;
+
+        await _repository.SaveAsync(new CachedText
+        {
+            IssueId = issueId,
+            LanguageId = languageCode,
+            TextTypeId = textTypeId,
+            Content = summary,
+            CachedAt = _timeProvider.GetUtcNow().UtcDateTime
+        }, cancellationToken);
+
+        _logger.LogDebug(
+            "[SummaryCacheService] Saved to cache: Issue {IssueId}, Language {LanguageCode}",
+            issueId,
+            languageCode);
+    }
+}

--- a/test/Olbrasoft.GitHub.Issues.Business.Tests/Summarization/SummaryCacheServiceTests.cs
+++ b/test/Olbrasoft.GitHub.Issues.Business.Tests/Summarization/SummaryCacheServiceTests.cs
@@ -1,0 +1,190 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Olbrasoft.GitHub.Issues.Business.Summarization;
+using Olbrasoft.GitHub.Issues.Data;
+using Olbrasoft.GitHub.Issues.Data.Entities;
+using Olbrasoft.GitHub.Issues.Data.Repositories;
+using Xunit;
+
+namespace Olbrasoft.GitHub.Issues.Business.Tests.Summarization;
+
+public class SummaryCacheServiceTests
+{
+    private readonly Mock<ICachedTextRepository> _mockRepository;
+    private readonly Mock<TimeProvider> _mockTimeProvider;
+    private readonly Mock<ILogger<SummaryCacheService>> _mockLogger;
+    private readonly SummaryCacheService _service;
+    private readonly DateTime _testTime;
+
+    public SummaryCacheServiceTests()
+    {
+        _mockRepository = new Mock<ICachedTextRepository>();
+        _mockTimeProvider = new Mock<TimeProvider>();
+        _mockLogger = new Mock<ILogger<SummaryCacheService>>();
+
+        _testTime = new DateTime(2025, 12, 29, 12, 0, 0, DateTimeKind.Utc);
+        _mockTimeProvider.Setup(t => t.GetUtcNow()).Returns(new DateTimeOffset(_testTime));
+
+        _service = new SummaryCacheService(
+            _mockRepository.Object,
+            _mockTimeProvider.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetIfFreshAsync_WhenCacheExists_ReturnsSummary()
+    {
+        // Arrange
+        const int issueId = 123;
+        const int languageCode = (int)LanguageCode.EnUS;
+        var issueUpdatedAt = _testTime.AddDays(-1);
+        const string expectedSummary = "Test summary";
+
+        _mockRepository
+            .Setup(r => r.GetIfFreshAsync(
+                issueId,
+                languageCode,
+                (int)TextTypeCode.ListSummary,
+                issueUpdatedAt,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedSummary);
+
+        // Act
+        var result = await _service.GetIfFreshAsync(issueId, languageCode, issueUpdatedAt);
+
+        // Assert
+        Assert.Equal(expectedSummary, result);
+        _mockRepository.Verify(r => r.GetIfFreshAsync(
+            issueId,
+            languageCode,
+            (int)TextTypeCode.ListSummary,
+            issueUpdatedAt,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetIfFreshAsync_WhenCacheDoesNotExist_ReturnsNull()
+    {
+        // Arrange
+        const int issueId = 123;
+        const int languageCode = (int)LanguageCode.CsCZ;
+        var issueUpdatedAt = _testTime.AddDays(-1);
+
+        _mockRepository
+            .Setup(r => r.GetIfFreshAsync(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        // Act
+        var result = await _service.GetIfFreshAsync(issueId, languageCode, issueUpdatedAt);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SaveAsync_SavesSummaryWithCorrectParameters()
+    {
+        // Arrange
+        const int issueId = 456;
+        const int languageCode = (int)LanguageCode.EnUS;
+        const string summary = "New summary";
+        CachedText? capturedCachedText = null;
+
+        _mockRepository
+            .Setup(r => r.SaveAsync(It.IsAny<CachedText>(), It.IsAny<CancellationToken>()))
+            .Callback<CachedText, CancellationToken>((ct, _) => capturedCachedText = ct)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _service.SaveAsync(issueId, languageCode, summary);
+
+        // Assert
+        Assert.NotNull(capturedCachedText);
+        Assert.Equal(issueId, capturedCachedText.IssueId);
+        Assert.Equal(languageCode, capturedCachedText.LanguageId);
+        Assert.Equal((int)TextTypeCode.ListSummary, capturedCachedText.TextTypeId);
+        Assert.Equal(summary, capturedCachedText.Content);
+        Assert.Equal(_testTime, capturedCachedText.CachedAt);
+
+        _mockRepository.Verify(r => r.SaveAsync(
+            It.IsAny<CachedText>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_UsesCzechLanguageCode()
+    {
+        // Arrange
+        const int issueId = 789;
+        const int languageCode = (int)LanguageCode.CsCZ;
+        const string summary = "Czech summary";
+        CachedText? capturedCachedText = null;
+
+        _mockRepository
+            .Setup(r => r.SaveAsync(It.IsAny<CachedText>(), It.IsAny<CancellationToken>()))
+            .Callback<CachedText, CancellationToken>((ct, _) => capturedCachedText = ct)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _service.SaveAsync(issueId, languageCode, summary);
+
+        // Assert
+        Assert.NotNull(capturedCachedText);
+        Assert.Equal((int)LanguageCode.CsCZ, capturedCachedText.LanguageId);
+    }
+
+    [Fact]
+    public async Task GetIfFreshAsync_PassesCancellationToken()
+    {
+        // Arrange
+        const int issueId = 999;
+        const int languageCode = (int)LanguageCode.EnUS;
+        var issueUpdatedAt = _testTime;
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+
+        _mockRepository
+            .Setup(r => r.GetIfFreshAsync(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<DateTime>(),
+                token))
+            .ReturnsAsync("summary");
+
+        // Act
+        await _service.GetIfFreshAsync(issueId, languageCode, issueUpdatedAt, token);
+
+        // Assert
+        _mockRepository.Verify(r => r.GetIfFreshAsync(
+            issueId,
+            languageCode,
+            (int)TextTypeCode.ListSummary,
+            issueUpdatedAt,
+            token), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PassesCancellationToken()
+    {
+        // Arrange
+        const int issueId = 888;
+        const int languageCode = (int)LanguageCode.CsCZ;
+        const string summary = "Test";
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+
+        // Act
+        await _service.SaveAsync(issueId, languageCode, summary, token);
+
+        // Assert
+        _mockRepository.Verify(r => r.SaveAsync(
+            It.IsAny<CachedText>(),
+            token), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

Part of IssueSummaryService SRP refactoring (#310).

Extracts cache operations into dedicated service following Single Responsibility Principle.

## Changes

- ✅ Add `ISummaryCacheService` interface for cache operations
- ✅ Implement `SummaryCacheService` with freshness validation
- ✅ Create 6 comprehensive unit tests (all passing)
- ✅ Register service in DI container

## Key Features

- Cache operations only (SRP compliance)
- Freshness validation using issue GitHubUpdatedAt timestamp
- Detailed logging (cache HIT/MISS)
- Full test coverage

## Test Results

```
Successful: 6, Failed: 0, Skipped: 0, Total: 6
```

## Related Issues

- Part of #310 (IssueSummaryService SRP refactoring)
- Prerequisite for #320 (IssueSummaryOrchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)