### PR TITLE
refactor: BodyPreviewGenerator → GeneratedRegex

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Business/Detail/BodyPreviewGenerator.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/Detail/BodyPreviewGenerator.cs
@@ -6,11 +6,49 @@ namespace Olbrasoft.GitHub.Issues.Business.Detail;
 /// Generates text previews from markdown content.
 /// Strips markdown formatting and truncates to specified length.
 /// </summary>
-public class BodyPreviewGenerator : IBodyPreviewGenerator
+public partial class BodyPreviewGenerator : IBodyPreviewGenerator
 {
+    [GeneratedRegex(@"```[\s\S]*?```", RegexOptions.Multiline)]
+    private static partial Regex CodeBlockPattern();
+
+    [GeneratedRegex(@"`[^`]+`")]
+    private static partial Regex InlineCodePattern();
+
+    [GeneratedRegex(@"^#+\s+", RegexOptions.Multiline)]
+    private static partial Regex HeaderPattern();
+
+    [GeneratedRegex(@"\[([^\]]+)\]\([^)]+\)")]
+    private static partial Regex LinkPattern();
+
+    [GeneratedRegex(@"!\[[^\]]*\]\([^)]+\)")]
+    private static partial Regex ImagePattern();
+
+    [GeneratedRegex(@"\*\*([^*]+)\*\*")]
+    private static partial Regex BoldPattern();
+
+    [GeneratedRegex(@"\*([^*]+)\*")]
+    private static partial Regex ItalicPattern();
+
+    [GeneratedRegex(@"__([^_]+)__")]
+    private static partial Regex BoldUnderscorePattern();
+
+    [GeneratedRegex(@"_([^_]+)_")]
+    private static partial Regex ItalicUnderscorePattern();
+
+    [GeneratedRegex(@"^>\s*", RegexOptions.Multiline)]
+    private static partial Regex BlockquotePattern();
+
+    [GeneratedRegex(@"^[-*_]{3,}\s*$", RegexOptions.Multiline)]
+    private static partial Regex HorizontalRulePattern();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespacePattern();
+
     /// <inheritdoc />
     public string CreatePreview(string body, int maxLength)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(maxLength);
+
         if (string.IsNullOrWhiteSpace(body))
         {
             return string.Empty;
@@ -18,42 +56,25 @@ public class BodyPreviewGenerator : IBodyPreviewGenerator
 
         var text = body;
 
-        // Remove code blocks
-        text = Regex.Replace(text, @"```[\s\S]*?```", " ", RegexOptions.Multiline);
-        text = Regex.Replace(text, @"`[^`]+`", " ");
-
-        // Remove headers
-        text = Regex.Replace(text, @"^#+\s+", "", RegexOptions.Multiline);
-
-        // Remove links but keep text: [text](url) -> text
-        text = Regex.Replace(text, @"\[([^\]]+)\]\([^)]+\)", "$1");
-
-        // Remove images: ![alt](url)
-        text = Regex.Replace(text, @"!\[[^\]]*\]\([^)]+\)", "");
-
-        // Remove bold/italic markers
-        text = Regex.Replace(text, @"\*\*([^*]+)\*\*", "$1");
-        text = Regex.Replace(text, @"\*([^*]+)\*", "$1");
-        text = Regex.Replace(text, @"__([^_]+)__", "$1");
-        text = Regex.Replace(text, @"_([^_]+)_", "$1");
-
-        // Remove blockquotes
-        text = Regex.Replace(text, @"^>\s*", "", RegexOptions.Multiline);
-
-        // Remove horizontal rules
-        text = Regex.Replace(text, @"^[-*_]{3,}\s*$", "", RegexOptions.Multiline);
-
-        // Normalize whitespace
-        text = Regex.Replace(text, @"\s+", " ");
+        text = CodeBlockPattern().Replace(text, " ");
+        text = InlineCodePattern().Replace(text, " ");
+        text = HeaderPattern().Replace(text, "");
+        text = ImagePattern().Replace(text, "");
+        text = LinkPattern().Replace(text, "$1");
+        text = BoldPattern().Replace(text, "$1");
+        text = ItalicPattern().Replace(text, "$1");
+        text = BoldUnderscorePattern().Replace(text, "$1");
+        text = ItalicUnderscorePattern().Replace(text, "$1");
+        text = BlockquotePattern().Replace(text, "");
+        text = HorizontalRulePattern().Replace(text, "");
+        text = WhitespacePattern().Replace(text, " ");
         text = text.Trim();
 
-        // Truncate if needed
         if (text.Length <= maxLength)
         {
             return text;
         }
 
-        // Try to truncate at word boundary
         var truncated = text[..maxLength];
         var lastSpace = truncated.LastIndexOf(' ');
         if (lastSpace > maxLength * 0.7)

--- a/src/Olbrasoft.GitHub.Issues.Business/Detail/BodyPreviewGenerator.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/Detail/BodyPreviewGenerator.cs
@@ -47,7 +47,7 @@ public partial class BodyPreviewGenerator : IBodyPreviewGenerator
     /// <inheritdoc />
     public string CreatePreview(string body, int maxLength)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(maxLength);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxLength, nameof(maxLength));
 
         if (string.IsNullOrWhiteSpace(body))
         {
@@ -59,8 +59,8 @@ public partial class BodyPreviewGenerator : IBodyPreviewGenerator
         text = CodeBlockPattern().Replace(text, " ");
         text = InlineCodePattern().Replace(text, " ");
         text = HeaderPattern().Replace(text, "");
-        text = ImagePattern().Replace(text, "");
         text = LinkPattern().Replace(text, "$1");
+        text = ImagePattern().Replace(text, "");
         text = BoldPattern().Replace(text, "$1");
         text = ItalicPattern().Replace(text, "$1");
         text = BoldUnderscorePattern().Replace(text, "$1");

--- a/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/BodyPreviewGeneratorTests.cs
+++ b/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/BodyPreviewGeneratorTests.cs
@@ -177,4 +177,24 @@ public class BodyPreviewGeneratorTests
         Assert.DoesNotContain("  ", result); // No double spaces
         Assert.Contains("Text with multiple spaces and newlines", result);
     }
+
+    [Fact]
+    public void CreatePreview_MixedMarkdown_StripsAllFormattingAndReturnsPlainText()
+    {
+        // Arrange
+        const string body = "# Title\n\nParagraph with **bold**, *italic*, `inline`, and [link](https://x.y).\n\n```\ncode block\n```\n\n> quote\n\n---\n\nEnd.";
+
+        // Act
+        var result = _generator.CreatePreview(body, 500);
+
+        // Assert
+        Assert.Equal("Title Paragraph with bold, italic, , and link. quote End.", result);
+    }
+
+    [Fact]
+    public void CreatePreview_NegativeMaxLength_ThrowsArgumentOutOfRangeException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => _generator.CreatePreview("any body", -1));
+    }
 }


### PR DESCRIPTION
<!-- claude-session: de922145-e40a-4c68-9605-63ecdf2ff8e4 -->

## Summary
- Convert runtime `Regex.Replace` calls in `BodyPreviewGenerator` to compiled `GeneratedRegex` partial methods (source generator) — same behavior, lower startup/per-call cost.
- Add `ArgumentOutOfRangeException.ThrowIfNegative(maxLength)` guard at the top of `CreatePreview`.

## Test plan
- [x] Positive: new `CreatePreview_MixedMarkdown_StripsAllFormattingAndReturnsPlainText` asserts full markdown sample reduces to expected plain text string
- [x] Negative: new `CreatePreview_NegativeMaxLength_ThrowsArgumentOutOfRangeException` asserts guard fires
- [x] All 14 `BodyPreviewGeneratorTests` pass locally (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)