### PR TITLE
fix: NU1605 package downgrade on main (Business.csproj)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Business/Olbrasoft.GitHub.Issues.Business.csproj
+++ b/src/Olbrasoft.GitHub.Issues.Business/Olbrasoft.GitHub.Issues.Business.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.*" />
     <PackageReference Include="Olbrasoft.Data.Cqrs" Version="*" />
     <PackageReference Include="Olbrasoft.Mediation" Version="*" />
   </ItemGroup>


### PR DESCRIPTION
<!-- claude-session: de922145-e40a-4c68-9605-63ecdf2ff8e4 -->

## Summary
Fixes the **NU1605** `package downgrade` error failing `Deploy GitHub.Issues (Local)` on every push to `main`.

`Business.csproj` pinned the following to `10.0.5`:
- `Microsoft.Extensions.Http`
- `Microsoft.Extensions.Logging.Abstractions`
- `Microsoft.Extensions.Options`

But the transitive chain (`Http 10.0.5 → Logging 10.0.6 → Logging.Abstractions >= 10.0.6`) forces 10.0.6, so the direct 10.0.5 pin is a downgrade.

Switched to the `10.0.*` floating range — same pattern already used in `Data.EntityFrameworkCore.csproj` — so NuGet always picks the latest patch and versions stay aligned across the solution.

## Test plan
- [x] `dotnet restore src/Olbrasoft.GitHub.Issues.Business/...csproj` — no NU1605, only pre-existing NU1608 warnings
- [x] `dotnet build src/Olbrasoft.GitHub.Issues.Business/...csproj` — 0 errors
- [ ] CI (`Deploy GitHub.Issues (Local)`) passes on this PR and on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)