### PR TITLE
test: add TryParse wrapper to IssueNumberParser (round-2 webhook test)

### DIFF
--- a/src/Olbrasoft.GitHub.Issues.Business/Detail/IssueNumberParser.cs
+++ b/src/Olbrasoft.GitHub.Issues.Business/Detail/IssueNumberParser.cs
@@ -23,6 +23,27 @@ public static partial class IssueNumberParser
     public record ParsedIssueNumber(int Number, string? RepositoryName);
 
     /// <summary>
+    /// Attempts to parse a single issue number from the query string.
+    /// Convenience wrapper around <see cref="Parse(string?)"/> for callers that only care about
+    /// a true/false answer plus the first match.
+    /// </summary>
+    /// <param name="query">Search query string</param>
+    /// <param name="result">The first parsed issue number, or <c>null</c> when no match was found.</param>
+    /// <returns><c>true</c> when at least one issue number was parsed; otherwise <c>false</c>.</returns>
+    public static bool TryParse(string? query, out ParsedIssueNumber? result)
+    {
+        var matches = Parse(query);
+        if (matches.Count == 0)
+        {
+            result = null;
+            return false;
+        }
+
+        result = matches[0];
+        return true;
+    }
+
+    /// <summary>
     /// Attempts to parse issue number(s) from the query string.
     /// </summary>
     /// <param name="query">Search query string</param>

--- a/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/IssueNumberParserTests.cs
+++ b/test/Olbrasoft.GitHub.Issues.Business.Tests/Services/IssueNumberParserTests.cs
@@ -126,6 +126,30 @@ public class IssueNumberParserTests
 
     #endregion
 
+    #region TryParse Tests
+
+    [Fact]
+    public void TryParse_HashNumber_ReturnsTrueWithFirstMatch()
+    {
+        var ok = IssueNumberParser.TryParse("#123", out var result);
+
+        Assert.True(ok);
+        Assert.NotNull(result);
+        Assert.Equal(123, result!.Number);
+        Assert.Null(result.RepositoryName);
+    }
+
+    [Fact]
+    public void TryParse_NonMatchingText_ReturnsFalseWithNullResult()
+    {
+        var ok = IssueNumberParser.TryParse("just some random text without numbers", out var result);
+
+        Assert.False(ok);
+        Assert.Null(result);
+    }
+
+    #endregion
+
     #region GetSemanticQuery Tests
 
     [Fact]


### PR DESCRIPTION
<!-- claude-session: de922145-e40a-4c68-9605-63ecdf2ff8e4 -->

## Summary
Round-2 webhook chain test after ghnotify classifier fix (commit `0d84f02`) — verifies that `code-review-complete` wake arrives for BOTH `action=submitted` AND `action=edited`, and that a dismissed review produces NO wake.

Adds a `TryParse` convenience wrapper on `IssueNumberParser` so call sites that only need a boolean + first match don't have to materialize the full `Parse` list.

## Test plan
- [x] Positive: `TryParse("#123", out var r)` → `true`, `r.Number == 123`
- [x] Negative: `TryParse("just some random text without numbers", out var r)` → `false`, `r == null`
- [x] All 22 `IssueNumberParserTests` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)