### PR TITLE
fix: clean app/ before dotnet publish to avoid stale DLLs

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -40,7 +40,19 @@ fi
 echo "✅ All tests passed"
 echo ""
 
-# Step 2: Build and publish
+# Step 2: Clean previous publish output
+# dotnet publish is incremental and will not always overwrite stale framework/dependency DLLs
+# (e.g. when NuGet resolves a floating version to a newer patch than last deploy). Wipe the
+# output directory so every deploy starts from a known-empty state — fixes runtime
+# FileNotFoundException for assemblies whose version changed between deploys.
+echo "🧹 Cleaning previous publish output..."
+if [ -d "$BASE_DIR/app" ]; then
+    rm -rf "$BASE_DIR/app"
+    echo "✅ Removed $BASE_DIR/app"
+fi
+echo ""
+
+# Step 3: Build and publish
 echo "🔨 Building and publishing..."
 dotnet publish src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages.csproj \
   -c Release \

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -21,6 +21,17 @@ if [ -z "$BASE_DIR" ]; then
   exit 1
 fi
 
+# Safety guard: BASE_DIR must be an absolute path under /opt/olbrasoft or /home — we rm -rf
+# $BASE_DIR/app later, so an unexpected value like "/" or "" would be catastrophic.
+case "$BASE_DIR" in
+    /opt/olbrasoft/*|/home/*)
+        ;;
+    *)
+        echo "❌ BASE_DIR must be an absolute path under /opt/olbrasoft/ or /home/ (got: $BASE_DIR)"
+        exit 1
+        ;;
+esac
+
 echo "╔══════════════════════════════════════════════════════════════╗"
 echo "║           GitHub.Issues Deploy Script                        ║"
 echo "╚══════════════════════════════════════════════════════════════╝"
@@ -62,7 +73,7 @@ dotnet publish src/Olbrasoft.GitHub.Issues.AspNetCore.RazorPages/Olbrasoft.GitHu
 echo "✅ Published to $BASE_DIR/app"
 echo ""
 
-# Step 3: Create directory structure
+# Step 4: Create directory structure
 echo "📁 Creating directory structure..."
 mkdir -p "$BASE_DIR/config"
 mkdir -p "$BASE_DIR/data"
@@ -71,7 +82,7 @@ mkdir -p "$BASE_DIR/logs"
 echo "✅ Directory structure created"
 echo ""
 
-# Step 4: Copy config if not exists
+# Step 5: Copy config if not exists
 if [ ! -f "$BASE_DIR/config/appsettings.json" ]; then
     echo "📝 Creating default appsettings.json..."
     if [ -f "$BASE_DIR/app/appsettings.json" ]; then


### PR DESCRIPTION
<!-- claude-session: de922145-e40a-4c68-9605-63ecdf2ff8e4 -->

## Summary
Every push to `main` since PR #361 landed fails in the `Deploy GitHub.Issues (Local)` workflow's **Restart application** step with:

```
Unhandled exception. System.IO.FileNotFoundException:
  Could not load file or assembly 'Microsoft.EntityFrameworkCore, Version=10.0.6.0, ...'
```

Root cause: `/opt/olbrasoft/github-issues/app/Microsoft.EntityFrameworkCore.dll` is a stale `10.0.5` DLL owned by `root`, left over from an earlier deploy. `dotnet publish` is incremental and, after NuGet floated `10.0.*` to `10.0.6`, msbuild's output tracking decided the file didn't need to be re-copied — so the build bin has `10.0.6` but `/opt/.../app/` still has `10.0.5`, producing a runtime version mismatch.

## Fix
Wipe `$BASE_DIR/app` before `dotnet publish` in `deploy.sh` so every deploy starts from a clean directory.

Safe under Linux semantics: the running app holds its open DLLs by inode refcount until `pkill` in the `Restart application` step, so removing directory entries underneath it does not break the still-running process.

## Test plan
- [ ] CI (`Deploy GitHub.Issues (Local)`) passes on `main` after merge, Restart step no longer throws FileNotFoundException, `curl http://localhost:5156` returns a status code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)